### PR TITLE
Return detailed error status when closing channel

### DIFF
--- a/src/commands/closeChannel.ts
+++ b/src/commands/closeChannel.ts
@@ -66,13 +66,18 @@ export default class CloseChannel extends Command {
 
     const { receipt, channelStatus } = await closeChannelRes.json()
 
-    if (channelStatus === 'Open') {
-      return log(
-        `Initiated channel closure, the channel must remain open for at least ${channelClosurePeriod} minutes. Please send the close command again once the cool-off has passed. Receipt: "${receipt}".`
-      )
+    if (direction === 'outgoing') {
+      if (channelStatus === 'Open') {
+        return log(
+          `Initiated channel closure, the channel must remain open for at least ${channelClosurePeriod} minutes. Please send the close command again once the cool-off has passed. Receipt: "${receipt}".`
+        )
+      } else {
+        if (receipt != undefined) return log(`Closed channel. Receipt: ${receipt}`)
+        else return log(`Closing channel, closure window still active.`)
+      }
     } else {
       if (receipt != undefined) return log(`Closed channel. Receipt: ${receipt}`)
-      else return log(`Closing channel, closure window still active.`)
+      else return log(`Closing incoming channel is not supported.`)
     }
   }
 }

--- a/src/commands/closeChannel.ts
+++ b/src/commands/closeChannel.ts
@@ -43,7 +43,7 @@ export default class CloseChannel extends Command {
       return log(
         await this.failedApiCall(closeChannelRes, `close channel with '${counterparty.toString()}'`, {
           400: `invalid peer ID ${counterparty.toString()}`,
-          422: (v) => v.error
+          422: (v) => v.status
         })
       )
     }


### PR DESCRIPTION
Current smart contract does not support closing incoming channel. To distinguish between a common error and this known issue, now UI returns "UNSUPPORTED_FEATURE" when closing an incoming channel.