### PR TITLE
Ws connection middleware for redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.0",
-    "@hoprnet/hopr-sdk": "^0.0.1-alpha.5",
+    "@hoprnet/hopr-sdk": "^0.0.1-alpha.7",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",
     "@reduxjs/toolkit": "^1.9.5",

--- a/src/sections/selectNode.tsx
+++ b/src/sections/selectNode.tsx
@@ -60,9 +60,11 @@ function Section1() {
       })
     );
     dispatch(authActionsAsync.loginThunk({ apiEndpoint, apiToken }));
-    dispatch(nodeActionsAsync.getInfoThunk({ apiToken, apiEndpoint })).unwrap().then(() => {
-      dispatch(nodeActions.initializeWebsocket())
-    });
+    dispatch(nodeActionsAsync.getInfoThunk({ apiToken, apiEndpoint }))
+      .unwrap()
+      .then(() => {
+        dispatch(nodeActions.initializeWebsocket());
+      });
   };
 
   const clearLocalNodes = () => {

--- a/src/sections/selectNode.tsx
+++ b/src/sections/selectNode.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';
 import { Store } from '../types/index';
 
 //Stores
 import { authActions, authActionsAsync } from '../store/slices/auth';
-import { nodeActions, nodeActionsAsync } from '../store/slices/node';
+import node, { nodeActionsAsync, nodeActions } from '../store/slices/node';
 
 // HOPR Components
 import Section from '../future-hopr-lib-components/Section';
@@ -60,7 +60,9 @@ function Section1() {
       })
     );
     dispatch(authActionsAsync.loginThunk({ apiEndpoint, apiToken }));
-    dispatch(nodeActionsAsync.getInfoThunk({ apiToken, apiEndpoint }));
+    dispatch(nodeActionsAsync.getInfoThunk({ apiToken, apiEndpoint })).unwrap().then(() => {
+      dispatch(nodeActions.initializeWebsocket())
+    });
   };
 
   const clearLocalNodes = () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import authSlice from './slices/auth';
 import sdkSlice from './slices/node';
 import safeSlice from './slices/safe';
 import web3Slice from './slices/web3';
+import { websocketMiddleware } from './slices/node/websocketMiddleware';
 
 const store = configureStore({
   reducer: {
@@ -13,6 +14,8 @@ const store = configureStore({
     safe: safeSlice,
     web3: web3Slice,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().prepend(websocketMiddleware),
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -669,6 +669,7 @@ export const createExtraReducers = (
       state.messages.push({
         body: action.payload.body,
         createdAt: Date.now(),
+        seen: false,
         challenge: action.payload.challenge,
       });
     }

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -1,7 +1,6 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { Action, PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { initialState } from './initialState';
 import { actionsAsync, createExtraReducers } from './actionsAsync';
-// TODO: assign Types from HOPR-SDK
 
 const nodeSlice = createSlice({
   name: 'node',
@@ -18,6 +17,18 @@ const nodeSlice = createSlice({
     },
     setInfo(state, action) {
       console.log('SDK getInfo', action);
+    },
+    messageReceived(
+      state,
+      action: PayloadAction<(typeof initialState.messages)[0]>
+    ) {
+      state.messages.push(action.payload);
+    },
+    initializeWebsocket(state) {
+      state.websocketConnected = true;
+    },
+    closeWebsocket(state) {
+      state.websocketConnected = false;
     },
   },
   extraReducers: (builder) => createExtraReducers(builder),

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -1,6 +1,6 @@
-import { Action, PayloadAction, createSlice } from '@reduxjs/toolkit';
-import { initialState } from './initialState';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { actionsAsync, createExtraReducers } from './actionsAsync';
+import { initialState } from './initialState';
 
 const nodeSlice = createSlice({
   name: 'node',

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -10,13 +10,10 @@ const nodeSlice = createSlice({
       console.log('SDK initiating');
       state.status.initiating = true;
     },
-    setInitiated(state, action) {
-      console.log('SDK setInitiated', action);
+    setInitiated(state) {
+      console.log('SDK setInitiated');
       state.status.initiating = false;
       state.status.initiated = true;
-    },
-    setInfo(state, action) {
-      console.log('SDK getInfo', action);
     },
     messageReceived(
       state,
@@ -24,12 +21,13 @@ const nodeSlice = createSlice({
     ) {
       state.messages.push(action.payload);
     },
-    initializeWebsocket(state) {
-      state.websocketConnected = true;
+    // handle ws state
+    updateWebsocketStatus(state, action: PayloadAction<boolean>) {
+      state.websocketConnected = action.payload;
     },
-    closeWebsocket(state) {
-      state.websocketConnected = false;
-    },
+    // user actions to open and close ws
+    initializeWebsocket() {},
+    closeWebsocket() {},
   },
   extraReducers: (builder) => createExtraReducers(builder),
 });

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -45,6 +45,7 @@ type InitialState = {
 };
 
 export const initialState: InitialState = {
+  info: null,
   status: {
     initiating: false,
     initiated: false,
@@ -64,7 +65,6 @@ export const initialState: InitialState = {
     observed: [],
   },
   entryNodes: null,
-  info: null,
   settings: null,
   statistics: null,
   tickets: [],

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -23,7 +23,12 @@ type InitialState = {
   aliases: GetAliasesResponseType | null;
   balances: AccountResponseType | null;
   channels: GetChannelsResponseType | null;
-  messages: { createdAt: number; body: string; challenge?: string }[];
+  messages: {
+    createdAt: number;
+    seen: boolean;
+    body: string;
+    challenge?: string;
+  }[];
   signedMessages: { createdAt: number; body: string }[];
   peers: GetPeersResponseType | null;
   entryNodes: GetEntryNodesResponseType | null;
@@ -36,6 +41,7 @@ type InitialState = {
   transactions: string[];
   pings: (PingNodeResponseType & { peerId: string })[];
   metrics: string | null;
+  websocketConnected: boolean;
 };
 
 export const initialState: InitialState = {
@@ -67,4 +73,5 @@ export const initialState: InitialState = {
   transactions: [],
   pings: [],
   metrics: null,
+  websocketConnected: false,
 };

--- a/src/store/slices/node/websocketMiddleware.ts
+++ b/src/store/slices/node/websocketMiddleware.ts
@@ -1,4 +1,4 @@
-import { api, utils } from '@hoprnet/hopr-sdk';
+import { utils } from '@hoprnet/hopr-sdk';
 import { Middleware, PayloadAction } from '@reduxjs/toolkit';
 import { initialState } from '../auth/initialState';
 import { nodeActions } from './index';
@@ -10,7 +10,6 @@ const {
   updateWebsocketStatus,
 } = nodeActions;
 
-const { getWsUrl } = api;
 const { WebsocketHelper } = utils;
 
 type LocalRootState = {
@@ -28,14 +27,10 @@ const websocketMiddleware: Middleware<{}, LocalRootState> = ({
       // start websocket connection
       const { apiEndpoint, apiToken } = getState().auth.loginData;
       if (apiEndpoint && apiToken) {
-        const wsUrl = getWsUrl(
-          apiEndpoint,
-          '/api/v2/messages/websocket/',
-          apiToken
-        );
         try {
           socket = new WebsocketHelper({
-            url: wsUrl,
+            apiEndpoint,
+            apiToken,
             onOpen: () => {
               dispatch(updateWebsocketStatus(true));
             },

--- a/src/store/slices/node/websocketMiddleware.ts
+++ b/src/store/slices/node/websocketMiddleware.ts
@@ -1,0 +1,77 @@
+import { websocket } from '@hoprnet/hopr-sdk/api';
+import { decodeMessage } from '@hoprnet/hopr-sdk/utils';
+import { Middleware, PayloadAction } from '@reduxjs/toolkit';
+import WebSocket from 'ws';
+import { initialState } from '../auth/initialState';
+import { nodeActions } from './index';
+
+const { messageReceived, initializeWebsocket, closeWebsocket } = nodeActions;
+
+type LocalRootState = {
+  auth: typeof initialState;
+};
+
+const websocketMiddleware: Middleware<{}, LocalRootState> = ({
+  dispatch,
+  getState,
+}) => {
+  let socket: WebSocket | null = null;
+
+  return (next) => (action: PayloadAction) => {
+    if (action.type === initializeWebsocket.type) {
+      // start websocket connection
+      const { apiEndpoint, apiToken } = getState().auth.loginData;
+      if (apiEndpoint && apiToken) {
+        socket = websocket({
+          apiEndpoint,
+          apiToken,
+        });
+
+        // add event listeners to socket
+        socket.onopen = () => {
+          dispatch(initializeWebsocket());
+        };
+
+        socket.onclose = () => {
+          dispatch(closeWebsocket());
+        };
+
+        socket.onmessage = (event) => {
+          const body = event.data.toString();
+          // message received is an acknowledgement of a
+          // message we have send, we can safely ignore this
+          if (body.startsWith('ack:')) return;
+
+          let message: string | undefined;
+          try {
+            message = decodeMessage(body);
+          } catch (error) {
+            console.error(error);
+          }
+          if (!message) return;
+
+          dispatch(
+            messageReceived({
+              body: message,
+              createdAt: Date.now(),
+              seen: false,
+            })
+          );
+        };
+
+        socket.onerror = (error) => {
+          console.error('WebSocket error:', error);
+          dispatch(closeWebsocket());
+        };
+      }
+    } else if (action.type === closeWebsocket.type) {
+      // close websocket
+      socket?.close();
+      dispatch(closeWebsocket());
+    }
+
+    return next(action);
+  };
+};
+
+export { websocketMiddleware };

--- a/src/store/slices/node/websocketMiddleware.ts
+++ b/src/store/slices/node/websocketMiddleware.ts
@@ -1,11 +1,17 @@
-import { websocket } from '@hoprnet/hopr-sdk/api';
-import { decodeMessage } from '@hoprnet/hopr-sdk/utils';
+import { api, utils } from '@hoprnet/hopr-sdk';
 import { Middleware, PayloadAction } from '@reduxjs/toolkit';
-import WebSocket from 'ws';
 import { initialState } from '../auth/initialState';
 import { nodeActions } from './index';
 
-const { messageReceived, initializeWebsocket, closeWebsocket } = nodeActions;
+const {
+  messageReceived,
+  initializeWebsocket,
+  closeWebsocket,
+  updateWebsocketStatus,
+} = nodeActions;
+
+const { getWsUrl } = api;
+const { WebsocketHelper } = utils;
 
 type LocalRootState = {
   auth: typeof initialState;
@@ -15,62 +21,49 @@ const websocketMiddleware: Middleware<{}, LocalRootState> = ({
   dispatch,
   getState,
 }) => {
-  let socket: WebSocket | null = null;
+  let socket: typeof WebsocketHelper.prototype | null = null;
 
   return (next) => (action: PayloadAction) => {
     if (action.type === initializeWebsocket.type) {
       // start websocket connection
       const { apiEndpoint, apiToken } = getState().auth.loginData;
       if (apiEndpoint && apiToken) {
-        socket = websocket({
+        const wsUrl = getWsUrl(
           apiEndpoint,
-          apiToken,
-        });
-
-        // add event listeners to socket
-        socket.onopen = () => {
-          dispatch(initializeWebsocket());
-        };
-
-        socket.onclose = () => {
-          dispatch(closeWebsocket());
-        };
-
-        socket.onmessage = (event) => {
-          const body = event.data.toString();
-          // message received is an acknowledgement of a
-          // message we have send, we can safely ignore this
-          if (body.startsWith('ack:')) return;
-
-          let message: string | undefined;
-          try {
-            message = decodeMessage(body);
-          } catch (error) {
-            console.error(error);
-          }
-          if (!message) return;
-
-          dispatch(
-            messageReceived({
-              body: message,
-              createdAt: Date.now(),
-              seen: false,
-            })
-          );
-        };
-
-        socket.onerror = (error) => {
-          console.error('WebSocket error:', error);
-          dispatch(closeWebsocket());
-        };
+          '/api/v2/messages/websocket/',
+          apiToken
+        );
+        try {
+          socket = new WebsocketHelper({
+            url: wsUrl,
+            onOpen: () => {
+              dispatch(updateWebsocketStatus(true));
+            },
+            onClose: () => {
+              dispatch(updateWebsocketStatus(false));
+            },
+            onMessage: (message) => {
+              dispatch(
+                messageReceived({
+                  body: message,
+                  createdAt: Date.now(),
+                  seen: false,
+                })
+              );
+            },
+          });
+        } catch (e) {
+          console.log(e);
+          dispatch(updateWebsocketStatus(false));
+        }
       }
     } else if (action.type === closeWebsocket.type) {
       // close websocket
       socket?.close();
-      dispatch(closeWebsocket());
+      dispatch(updateWebsocketStatus(false));
+    } else {
+      return next(action);
     }
-
-    return next(action);
   };
 };
 

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,0 +1,5 @@
+import store from '../store';
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// // Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,9 +1791,9 @@
     "@ethersproject/strings" "^5.7.0"
 
 "@fontsource/roboto@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.0.1.tgz#c9d374fc71553d356986b393ec8aace1bf740d58"
-  integrity sha512-pWF64nF35Tfoh2kWgOuJYEFTLkpn+O3/GIR//u1MGD9b1yR+UBwYKXmcNx9CRyNPjMdWjkdN9GKDHhaWZRYbnw==
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.0.2.tgz#06f10be117be622e6c720a1c6579b00475420bcd"
+  integrity sha512-SLw0o3kWwJ53/Ogyk8GGwSaULNX6Hogs+GsVempDdqpX8wm5hKBLYgUkdUPk+NogiViPp1x++OnkuLA+fAd9Kg==
 
 "@hoprnet/hopr-sdk@^0.0.1-alpha.5":
   version "0.0.1-alpha.5"
@@ -3077,9 +3077,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*":
-  version "29.5.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.1.tgz#83c818aa9a87da27d6da85d3378e5a34d2f31a47"
-  integrity sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==
+  version "29.5.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.2.tgz#86b4afc86e3a8f3005b297ed8a72494f89e6395b"
+  integrity sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -3138,9 +3138,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.1.5":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
-  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
+  integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
 
 "@types/prop-types@*", "@types/prop-types@^15.7.5":
   version "15.7.5"
@@ -4671,9 +4671,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
-  version "1.0.30001491"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz#eab0e0f392de6f7411751d148de9b5bd6b203e46"
-  integrity sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==
+  version "1.0.30001492"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz#4a06861788a52b4c81fd3344573b68cc87fe062b"
+  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -5550,9 +5550,9 @@ ejs@^3.1.6:
     jake "^10.8.5"
 
 electron-to-chromium@^1.4.411:
-  version "1.4.413"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.413.tgz#0067c3122946ae234cbefb9401ecefde851cdcf2"
-  integrity sha512-Gd+/OAhRca06dkVxIQo/W7dr6Nmk9cx6lQdZ19GvFp51k5B/lUAokm6SJfNkdV8kFLsC3Z4sLTyEHWCnB1Efbw==
+  version "1.4.414"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.414.tgz#f9eedb6fb01b50439d8228d8ee3a6fa5e0108437"
+  integrity sha512-RRuCvP6ekngVh2SAJaOKT/hxqc9JAsK+Pe0hP5tGQIfonU2Zy9gMGdJ+mBdyl/vNucMG6gkXYtuM4H/1giws5w==
 
 elliptic@6.5.4:
   version "6.5.4"
@@ -7000,9 +7000,9 @@ ipaddr.js@1.9.1:
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 ipaddr.js@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
-  integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.1.0.tgz#2119bc447ff8c257753b196fc5f1ce08a4cdf39f"
+  integrity sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==
 
 is-arguments@^1.0.4, is-arguments@^1.1.1:
   version "1.1.1"
@@ -9737,9 +9737,9 @@ react-is@^18.0.0, react-is@^18.2.0:
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-redux@^8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.5.tgz#e5fb8331993a019b8aaf2e167a93d10af469c7bd"
-  integrity sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.7.tgz#b74ef2f7ce2076e354540aa3511d3670c2b62571"
+  integrity sha512-1vRQuCQI5Y2uNmrMXg81RXKiBHY3jBzvCvNmZF437O/Z9/pZ+ba2uYHbemYXb3g8rjsacBGo+/wmfrQKzMhJsg==
   dependencies:
     "@babel/runtime" "^7.12.1"
     "@types/hoist-non-react-statics" "^3.3.1"
@@ -11436,9 +11436,9 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.64.4:
-  version "5.84.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.84.1.tgz#d4493acdeca46b26ffc99d86d784cabfeb925a15"
-  integrity sha512-ZP4qaZ7vVn/K8WN/p990SGATmrL1qg4heP/MrVneczYtpDGJWlrgZv55vxaV2ul885Kz+25MP2kSXkPe3LZfmg==
+  version "5.85.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.85.0.tgz#c14a6a3a91f84d67c450225661fda8da36bc7f49"
+  integrity sha512-7gazTiYqwo5OSqwH1tigLDL2r3qDeP2dOKYgd+LlXpsUMqDTklg6tOghexqky0/+6QY38kb/R/uRPUleuL43zg==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.0"
@@ -11579,25 +11579,25 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workbox-background-sync@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-6.6.0.tgz#058c300672d589b1d8f2d838d940a371bcd0ec09"
-  integrity sha512-jkf4ZdgOJxC9u2vztxLuPT/UjlH7m/nWRQ/MgGL0v8BJHoZdVGJd18Kck+a0e55wGXdqyHO+4IQTk0685g4MUw==
+workbox-background-sync@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-6.6.1.tgz#08d603a33717ce663e718c30cc336f74909aff2f"
+  integrity sha512-trJd3ovpWCvzu4sW0E8rV3FUyIcC0W8G+AZ+VcqzzA890AsWZlUGOTSxIMmIHVusUw/FDq1HFWfy/kC/WTRqSg==
   dependencies:
     idb "^7.0.1"
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-broadcast-update@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-6.6.0.tgz#0abb9b638c5fe70e1305161df76db1926ff83d21"
-  integrity sha512-nm+v6QmrIFaB/yokJmQ/93qIJ7n72NICxIwQwe5xsZiV2aI93MGGyEyzOzDPVz5THEr5rC3FJSsO3346cId64Q==
+workbox-broadcast-update@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-6.6.1.tgz#0fad9454cf8e4ace0c293e5617c64c75d8a8c61e"
+  integrity sha512-fBhffRdaANdeQ1V8s692R9l/gzvjjRtydBOvR6WCSB0BNE2BacA29Z4r9/RHd9KaXCPl6JTdI9q0bR25YKP8TQ==
   dependencies:
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-build@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-6.6.0.tgz#8bb7a4b86cda95b72a303d91ee5dc5bd887775c1"
-  integrity sha512-Tjf+gBwOTuGyZwMz2Nk/B13Fuyeo0Q84W++bebbVsfr9iLkDSo6j6PST8tET9HYA58mlRXwlMGpyWO8ETJiXdQ==
+workbox-build@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-6.6.1.tgz#6010e9ce550910156761448f2dbea8cfcf759cb0"
+  integrity sha512-INPgDx6aRycAugUixbKgiEQBWD0MPZqU5r0jyr24CehvNuLPSXp/wGOpdRJmts656lNiXwqV7dC2nzyrzWEDnw==
   dependencies:
     "@apideck/better-ajv-errors" "^0.3.1"
     "@babel/core" "^7.11.1"
@@ -11621,132 +11621,132 @@ workbox-build@6.6.0:
     strip-comments "^2.0.1"
     tempy "^0.6.0"
     upath "^1.2.0"
-    workbox-background-sync "6.6.0"
-    workbox-broadcast-update "6.6.0"
-    workbox-cacheable-response "6.6.0"
-    workbox-core "6.6.0"
-    workbox-expiration "6.6.0"
-    workbox-google-analytics "6.6.0"
-    workbox-navigation-preload "6.6.0"
-    workbox-precaching "6.6.0"
-    workbox-range-requests "6.6.0"
-    workbox-recipes "6.6.0"
-    workbox-routing "6.6.0"
-    workbox-strategies "6.6.0"
-    workbox-streams "6.6.0"
-    workbox-sw "6.6.0"
-    workbox-window "6.6.0"
+    workbox-background-sync "6.6.1"
+    workbox-broadcast-update "6.6.1"
+    workbox-cacheable-response "6.6.1"
+    workbox-core "6.6.1"
+    workbox-expiration "6.6.1"
+    workbox-google-analytics "6.6.1"
+    workbox-navigation-preload "6.6.1"
+    workbox-precaching "6.6.1"
+    workbox-range-requests "6.6.1"
+    workbox-recipes "6.6.1"
+    workbox-routing "6.6.1"
+    workbox-strategies "6.6.1"
+    workbox-streams "6.6.1"
+    workbox-sw "6.6.1"
+    workbox-window "6.6.1"
 
-workbox-cacheable-response@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-6.6.0.tgz#f6e453c1da1491392ba30e1070a10ce4e853950b"
-  integrity sha512-JfhJUSQDwsF1Xv3EV1vWzSsCOZn4mQ38bWEBR3LdvOxSPgB65gAM6cS2CX8rkkKHRgiLrN7Wxoyu+TuH67kHrw==
+workbox-cacheable-response@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-6.6.1.tgz#284c2b86be3f4fd191970ace8c8e99797bcf58e9"
+  integrity sha512-85LY4veT2CnTCDxaVG7ft3NKaFbH6i4urZXgLiU4AiwvKqS2ChL6/eILiGRYXfZ6gAwDnh5RkuDbr/GMS4KSag==
   dependencies:
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-core@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-6.6.0.tgz#d0f6929e338e0025d412291390e7462a5f879576"
-  integrity sha512-GDtFRF7Yg3DD859PMbPAYPeJyg5gJYXuBQAC+wyrWuuXgpfoOrIQIvFRZnQ7+czTIQjIr1DhLEGFzZanAT/3bQ==
+workbox-core@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-6.6.1.tgz#7184776d4134c5ed2f086878c882728fc9084265"
+  integrity sha512-ZrGBXjjaJLqzVothoE12qTbVnOAjFrHDXpZe7coCb6q65qI/59rDLwuFMO4PcZ7jcbxY+0+NhUVztzR/CbjEFw==
 
-workbox-expiration@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-6.6.0.tgz#2299c86a9c9dcca17eec48f68ac88b8652bc8e4e"
-  integrity sha512-baplYXcDHbe8vAo7GYvyAmlS4f6998Jff513L4XvlzAOxcl8F620O91guoJ5EOf5qeXG4cGdNZHkkVAPouFCpw==
+workbox-expiration@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-6.6.1.tgz#a841fa36676104426dbfb9da1ef6a630b4f93739"
+  integrity sha512-qFiNeeINndiOxaCrd2DeL1Xh1RFug3JonzjxUHc5WkvkD2u5abY3gZL1xSUNt3vZKsFFGGORItSjVTVnWAZO4A==
   dependencies:
     idb "^7.0.1"
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-google-analytics@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-6.6.0.tgz#0db99ba0a08fcd67ddcfce255ebd74d83fc61ba1"
-  integrity sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==
+workbox-google-analytics@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-6.6.1.tgz#a07a6655ab33d89d1b0b0a935ffa5dea88618c5d"
+  integrity sha512-1TjSvbFSLmkpqLcBsF7FuGqqeDsf+uAXO/pjiINQKg3b1GN0nBngnxLcXDYo1n/XxK4N7RaRrpRlkwjY/3ocuA==
   dependencies:
-    workbox-background-sync "6.6.0"
-    workbox-core "6.6.0"
-    workbox-routing "6.6.0"
-    workbox-strategies "6.6.0"
+    workbox-background-sync "6.6.1"
+    workbox-core "6.6.1"
+    workbox-routing "6.6.1"
+    workbox-strategies "6.6.1"
 
-workbox-navigation-preload@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-6.6.0.tgz#2f2dbb7178c5762a163dd2f3b22ffd586704f3af"
-  integrity sha512-utNEWG+uOfXdaZmvhshrh7KzhDu/1iMHyQOV6Aqup8Mm78D286ugu5k9MFD9SzBT5TcwgwSORVvInaXWbvKz9Q==
+workbox-navigation-preload@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-6.6.1.tgz#61a34fe125558dd88cf09237f11bd966504ea059"
+  integrity sha512-DQCZowCecO+wRoIxJI2V6bXWK6/53ff+hEXLGlQL4Rp9ZaPDLrgV/32nxwWIP7QpWDkVEtllTAK5h6cnhxNxDA==
   dependencies:
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-precaching@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-6.6.0.tgz#8c701473316427fafad559e26adfb44b72ae6ffc"
-  integrity sha512-eYu/7MqtRZN1IDttl/UQcSZFkHP7dnvr/X3Vn6Iw6OsPMruQHiVjjomDFCNtd8k2RdjLs0xiz9nq+t3YVBcWPw==
+workbox-precaching@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-6.6.1.tgz#dedeeba10a2d163d990bf99f1c2066ac0d1a19e2"
+  integrity sha512-K4znSJ7IKxCnCYEdhNkMr7X1kNh8cz+mFgx9v5jFdz1MfI84pq8C2zG+oAoeE5kFrUf7YkT5x4uLWBNg0DVZ5A==
   dependencies:
-    workbox-core "6.6.0"
-    workbox-routing "6.6.0"
-    workbox-strategies "6.6.0"
+    workbox-core "6.6.1"
+    workbox-routing "6.6.1"
+    workbox-strategies "6.6.1"
 
-workbox-range-requests@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-6.6.0.tgz#dc6e89ca1694e442075fc7fa7ad9f3c4694a848e"
-  integrity sha512-V3aICz5fLGq5DpSYEU8LxeXvsT//mRWzKrfBOIxzIdQnV/Wj7R+LyJVTczi4CQ4NwKhAaBVaSujI1cEjXW+hTw==
+workbox-range-requests@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-6.6.1.tgz#ddaf7e73af11d362fbb2f136a9063a4c7f507a39"
+  integrity sha512-4BDzk28govqzg2ZpX0IFkthdRmCKgAKreontYRC5YsAPB2jDtPNxqx3WtTXgHw1NZalXpcH/E4LqUa9+2xbv1g==
   dependencies:
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-recipes@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-recipes/-/workbox-recipes-6.6.0.tgz#bec06d4f5605b12e983d08ccbac4e70932496c6c"
-  integrity sha512-TFi3kTgYw73t5tg73yPVqQC8QQjxJSeqjXRO4ouE/CeypmP2O/xqmB/ZFBBQazLTPxILUQ0b8aeh0IuxVn9a6A==
+workbox-recipes@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-recipes/-/workbox-recipes-6.6.1.tgz#ea70d2b2b0b0bce8de0a9d94f274d4a688e69fae"
+  integrity sha512-/oy8vCSzromXokDA+X+VgpeZJvtuf8SkQ8KL0xmRivMgJZrjwM3c2tpKTJn6PZA6TsbxGs3Sc7KwMoZVamcV2g==
   dependencies:
-    workbox-cacheable-response "6.6.0"
-    workbox-core "6.6.0"
-    workbox-expiration "6.6.0"
-    workbox-precaching "6.6.0"
-    workbox-routing "6.6.0"
-    workbox-strategies "6.6.0"
+    workbox-cacheable-response "6.6.1"
+    workbox-core "6.6.1"
+    workbox-expiration "6.6.1"
+    workbox-precaching "6.6.1"
+    workbox-routing "6.6.1"
+    workbox-strategies "6.6.1"
 
-workbox-routing@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-6.6.0.tgz#30128a649b8460c557ad0e70353077e325400558"
-  integrity sha512-x8gdN7VDBiLC03izAZRfU+WKUXJnbqt6PG9Uh0XuPRzJPpZGLKce/FkOX95dWHRpOHWLEq8RXzjW0O+POSkKvw==
+workbox-routing@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-6.6.1.tgz#cba9a1c7e0d1ea11e24b6f8c518840efdc94f581"
+  integrity sha512-j4ohlQvfpVdoR8vDYxTY9rA9VvxTHogkIDwGdJ+rb2VRZQ5vt1CWwUUZBeD/WGFAni12jD1HlMXvJ8JS7aBWTg==
   dependencies:
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-strategies@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-6.6.0.tgz#71bb60a46ebaa0c528491b8b521f5a1c7b35f0c5"
-  integrity sha512-eC07XGuINAKUWDnZeIPdRdVja4JQtTuc35TZ8SwMb1ztjp7Ddq2CJ4yqLvWzFWGlYI7CG/YGqaETntTxBGdKgQ==
+workbox-strategies@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-6.6.1.tgz#38d0f0fbdddba97bd92e0c6418d0b1a2ccd5b8bf"
+  integrity sha512-WQLXkRnsk4L81fVPkkgon1rZNxnpdO5LsO+ws7tYBC6QQQFJVI6v98klrJEjFtZwzw/mB/HT5yVp7CcX0O+mrw==
   dependencies:
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
-workbox-streams@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-6.6.0.tgz#0be1ba8b4fc692aef5ffefa831f5e9bbeee0fd9c"
-  integrity sha512-rfMJLVvwuED09CnH1RnIep7L9+mj4ufkTyDPVaXPKlhi9+0czCu+SJggWCIFbPpJaAZmp2iyVGLqS3RUmY3fxg==
+workbox-streams@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-6.6.1.tgz#b2f7ba7b315c27a6e3a96a476593f99c5d227d26"
+  integrity sha512-maKG65FUq9e4BLotSKWSTzeF0sgctQdYyTMq529piEN24Dlu9b6WhrAfRpHdCncRS89Zi2QVpW5V33NX8PgH3Q==
   dependencies:
-    workbox-core "6.6.0"
-    workbox-routing "6.6.0"
+    workbox-core "6.6.1"
+    workbox-routing "6.6.1"
 
-workbox-sw@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-6.6.0.tgz#e07d85a8af3a4ae311ba6e45d179ecaa402d4983"
-  integrity sha512-R2IkwDokbtHUE4Kus8pKO5+VkPHD2oqTgl+XJwh4zbF1HyjAbgNmK/FneZHVU7p03XUt9ICfuGDYISWG9qV/CQ==
+workbox-sw@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-6.6.1.tgz#d4c4ca3125088e8b9fd7a748ed537fa0247bd72c"
+  integrity sha512-R7whwjvU2abHH/lR6kQTTXLHDFU2izht9kJOvBRYK65FbwutT4VvnUAJIgHvfWZ/fokrOPhfoWYoPCMpSgUKHQ==
 
 workbox-webpack-plugin@^6.4.1:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-6.6.0.tgz#3a6fc298ffb546d0bd1572f3aa2f43fcdb9cd40b"
-  integrity sha512-xNZIZHalboZU66Wa7x1YkjIqEy1gTR+zPM+kjrYJzqN7iurYZBctBLISyScjhkJKYuRrZUP0iqViZTh8rS0+3A==
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-6.6.1.tgz#4f81cc1ad4e5d2cd7477a86ba83c84ee2d187531"
+  integrity sha512-zpZ+ExFj9NmiI66cFEApyjk7hGsfJ1YMOaLXGXBoZf0v7Iu6hL0ZBe+83mnDq3YYWAfA3fnyFejritjOHkFcrA==
   dependencies:
     fast-json-stable-stringify "^2.1.0"
     pretty-bytes "^5.4.1"
     upath "^1.2.0"
     webpack-sources "^1.4.3"
-    workbox-build "6.6.0"
+    workbox-build "6.6.1"
 
-workbox-window@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/workbox-window/-/workbox-window-6.6.0.tgz#a1b738340ea83323978ea9acc8f527c9240656d6"
-  integrity sha512-L4N9+vka17d16geaJXXRjENLFldvkWy7JyGxElRD0JvBxvFEd8LOhr+uXCcar/NzAmIBRv9EZ+M+Qr4mOoBITw==
+workbox-window@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/workbox-window/-/workbox-window-6.6.1.tgz#f22a394cbac36240d0dadcbdebc35f711bb7b89e"
+  integrity sha512-wil4nwOY58nTdCvif/KEZjQ2NP8uk3gGeRNy2jPBbzypU4BT4D9L8xiwbmDBpZlSgJd2xsT9FvSNU0gsxV51JQ==
   dependencies:
     "@types/trusted-types" "^2.0.2"
-    workbox-core "6.6.0"
+    workbox-core "6.6.1"
 
 wrap-ansi@^6.2.0:
   version "6.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,12 +1795,13 @@
   resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.0.2.tgz#06f10be117be622e6c720a1c6579b00475420bcd"
   integrity sha512-SLw0o3kWwJ53/Ogyk8GGwSaULNX6Hogs+GsVempDdqpX8wm5hKBLYgUkdUPk+NogiViPp1x++OnkuLA+fAd9Kg==
 
-"@hoprnet/hopr-sdk@^0.0.1-alpha.5":
-  version "0.0.1-alpha.5"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-0.0.1-alpha.5.tgz#6a9f347de7cd8de141c01076e5c160284853b75c"
-  integrity sha512-YQ5MsJY/mqow2ZOMRuVr+fhOOQACLOLGCcnHLy/OacBxranPlDdwZMt702ZjCfVxujqaQfVWgvvV1vzJmZ9y0w==
+"@hoprnet/hopr-sdk@^0.0.1-alpha.7":
+  version "0.0.1-alpha.7"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-0.0.1-alpha.7.tgz#657a456bf2996a63346aaa951ad16fcd333f064a"
+  integrity sha512-UFiLuH5RcLejfRzKa4MfTaQOCj5Fb5cxOcw41tW+Lc+GRQVvk5WtjjuZ2ujgO/WtYRhfRs9jsDrVtvOQy5SwWw==
   dependencies:
     cross-fetch "^3.1.5"
+    debug "^4.3.4"
     isomorphic-ws "^5.0.0"
     rlp "^3.0.0"
     ws "^8.13.0"


### PR DESCRIPTION
closes #19 

### How does this work? 
[Redux middleware](https://redux.js.org/understanding/history-and-design/middleware#the-final-approach) it provides a third-party extension point between dispatching an action, and the moment it reaches the reducer. So when a initializeWebsocket action is triggered it will first run run through the middleware creating a websocket connection before reaching the actual reducer.

### Why?
The WebSocket instance is not serializable and thus technically not something that should be stored in Redux state. So there were 2 alternatives considered in this pr:

#### [rtk query streaming updates](https://redux-toolkit.js.org/rtk-query/usage/streaming-updates)
With this solution we could have an easy way to mount ws connection and tear it down, however there are a lot of concepts the team would need to learn and it also provides less customization. 

#### custom redux middleware
Even though this solution is more code, the concept of middleware is easier to understand and provides us a solution that can adapter better to any changes that may happen on hoprd side.


### why was LocalRootState created?
The middleware has access to the whole store, however I could not reference the store type inside the actual middleware because the middleware will be used in the store. That would create a circular dependency. We could create the RootStore type by hand instead of inferring but I think the store is more likely to change than the middleware.

### How can this be better?
- add common ws logic to hopr-sdk and use it here