### PR TITLE
fix types in auth state

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -32,7 +32,7 @@ export const applicationMap = [
         name: 'Info',
         path: 'info',
         icon: <MailIcon />,
-        element: <SectionInfo/>,
+        element: <SectionInfo />,
       },
       {
         name: 'Configuration',

--- a/src/sections/info.tsx
+++ b/src/sections/info.tsx
@@ -24,16 +24,10 @@ function Section1() {
       apiKey: elem.apiKey,
     };
   });
-  const sdk = useAppSelector(
-    (store: Store) => store.sdk
-  );
+  const sdk = useAppSelector((store: Store) => store.sdk);
 
   return (
-    <Section
-      className="Section--selectNode"
-      id="Section--selectNode"
-      yellow
-    >
+    <Section className="Section--selectNode" id="Section--selectNode" yellow>
       Node sdk REDUX STORE
       <pre>{JSON.stringify(sdk, null, 4)}</pre>
     </Section>

--- a/src/sections/selectNode.tsx
+++ b/src/sections/selectNode.tsx
@@ -47,7 +47,7 @@ function Section1() {
         apiToken: saveApiToken ? apiToken : '',
       })
     );
-    dispatch(authActionsAsync.login({ apiEndpoint, apiToken }));
+    dispatch(authActionsAsync.loginThunk({ apiEndpoint, apiToken }));
     dispatch(nodeActionsAsync.getInfoThunk({ apiToken, apiEndpoint }));
   };
 
@@ -59,7 +59,7 @@ function Section1() {
         apiToken: saveApiToken ? apiToken : '',
       })
     );
-    dispatch(authActionsAsync.login({ apiEndpoint, apiToken }));
+    dispatch(authActionsAsync.loginThunk({ apiEndpoint, apiToken }));
     dispatch(nodeActionsAsync.getInfoThunk({ apiToken, apiEndpoint }));
   };
 

--- a/src/store/slices/auth/actionsAsync.ts
+++ b/src/store/slices/auth/actionsAsync.ts
@@ -1,18 +1,23 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
 import { authActions } from './index';
 import { api } from '@hoprnet/hopr-sdk';
 const { getInfo } = api;
 
-export const login = (loginData: { apiToken: string; apiEndpoint: string }) => {
-  return async (dispatch: any) => {
+export const loginThunk = createAsyncThunk(
+  'auth/login',
+  async (
+    loginData: { apiToken: string; apiEndpoint: string },
+    { dispatch }
+  ) => {
     const info = await getInfo({
       apiEndpoint: loginData.apiEndpoint,
       apiToken: loginData.apiToken,
     });
     console.log({ info });
     if (info) dispatch(authActions.setConnected());
-  };
-};
+  }
+);
 
 export const actionsAsync = {
-  login,
+  loginThunk,
 };

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { initialState } from './initialState';
 import { actionsAsync } from './actionsAsync';
 
@@ -6,30 +6,36 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    useNodeData(state, action) {
-      state.loginData.ip = action.payload.ip;
-      state.loginData.apiKey = action.payload.apiKey;
+    useNodeData(
+      state,
+      action: PayloadAction<{ apiToken: string; apiEndpoint: string }>
+    ) {
+      state.loginData.apiEndpoint = action.payload.apiEndpoint;
+      state.loginData.apiToken = action.payload.apiToken;
       state.status.connecting = true;
     },
     setConnected(state) {
       state.status.connecting = false;
       state.status.connected = true;
     },
-    addNodeData(state, action) {
+    addNodeData(
+      state,
+      action: PayloadAction<{ apiToken: string; apiEndpoint: string }>
+    ) {
       const newItem = action.payload;
       const existingItem = state.nodes.findIndex(
-        (item: { ip: string }) => item.ip === newItem.ip
+        (item) => item.apiEndpoint === newItem.apiEndpoint
       );
       if (existingItem === -1) {
         state.nodes = [
           {
-            ip: action.payload.ip,
-            apiKey: action.payload.apiKey,
+            apiEndpoint: action.payload.apiEndpoint,
+            apiToken: action.payload.apiToken,
           },
           ...state.nodes,
         ];
       } else {
-        state.nodes[existingItem].apiKey = action.payload.apiKey;
+        state.nodes[existingItem].apiToken = action.payload.apiToken;
       }
 
       localStorage.setItem('admin-ui-node-list', JSON.stringify(state.nodes));

--- a/src/store/slices/auth/initialState.ts
+++ b/src/store/slices/auth/initialState.ts
@@ -2,15 +2,28 @@ import { getObjectFromLocalStorage } from '../../../utils/functions';
 
 const ADMIN_UI_NODE_LIST = getObjectFromLocalStorage('admin-ui-node-list');
 
-export const initialState = {
+type InitialState = {
   status: {
-    connecting: false as boolean,
-    connected: false as boolean,
+    connecting: boolean;
+    connected: boolean;
+  };
+  loginData: {
+    apiEndpoint: string | null;
+    apiToken: string | null;
+    peerId: string | null;
+  };
+  nodes: { apiEndpoint: string | null; apiToken: string | null }[];
+};
+
+export const initialState: InitialState = {
+  status: {
+    connecting: false,
+    connected: false,
   },
   loginData: {
-    ip: null as string | null,
-    apiKey: null as string | null,
-    peerId: null as string | null,
+    apiEndpoint: null,
+    apiToken: null,
+    peerId: null,
   },
-  nodes: ADMIN_UI_NODE_LIST ? ADMIN_UI_NODE_LIST : ([] as {}[]),
+  nodes: ADMIN_UI_NODE_LIST ? ADMIN_UI_NODE_LIST : [],
 };


### PR DESCRIPTION
### overview
This was an error that stricter types could have caught. some values on auth state still had `ip` and `apiKey` but the actions were sending `apiToken` and `apiEndpoint`. With this pr it will fix that and prevent this from happening on auth slice.