### PR TITLE
Peers subpage

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,7 @@ import InboxIcon from '@mui/icons-material/MoveToInbox';
 import Layout from './future-hopr-lib-components/Layout';
 import AliasesPage from './sections/aliases';
 import InfoPage from './sections/info';
+import PeersPage from './sections/peers';
 
 export const applicationMap = [
   // {
@@ -34,6 +35,12 @@ export const applicationMap = [
         path: 'info',
         icon: <MailIcon />,
         element: <InfoPage />,
+      },
+      {
+        name: 'Peers',
+        path: 'peers',
+        icon: <MailIcon />,
+        element: <PeersPage />,
       },
       {
         name: 'Configuration',

--- a/src/sections/peers.tsx
+++ b/src/sections/peers.tsx
@@ -66,7 +66,7 @@ function PeersPage() {
           </TableHead>
           <TableBody>
             {Object.entries(peers?.announced ?? {}).map(([id, peer], key) => (
-              <TableRow key={key}>
+              <TableRow key={id}>
                 <TableCell component="th" scope="row">
                   {id}
                 </TableCell>

--- a/src/sections/peers.tsx
+++ b/src/sections/peers.tsx
@@ -1,0 +1,109 @@
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { useEffect } from 'react';
+import Section from '../future-hopr-lib-components/Section';
+import { useAppDispatch, useAppSelector } from '../store';
+import { actionsAsync } from '../store/slices/node/actionsAsync';
+
+function PeersPage() {
+  const dispatch = useAppDispatch();
+  const loginData = useAppSelector((selector) => selector.auth.loginData);
+  const peers = useAppSelector((selector) => selector.sdk.peers);
+  const aliases = useAppSelector((selector) => selector.sdk.aliases);
+
+  useEffect(() => {
+    dispatch(
+      actionsAsync.getPeersThunk({
+        apiEndpoint: loginData.apiEndpoint!,
+        apiToken: loginData.apiToken!,
+      })
+    );
+    dispatch(
+      actionsAsync.getAliasesThunk({
+        apiEndpoint: loginData.apiEndpoint!,
+        apiToken: loginData.apiToken!,
+      })
+    );
+  }, [loginData, dispatch]);
+
+  const handleRefresh = () => {
+    dispatch(
+      actionsAsync.getPeersThunk({
+        apiEndpoint: loginData.apiEndpoint!,
+        apiToken: loginData.apiToken!,
+      })
+    );
+    dispatch(
+      actionsAsync.getAliasesThunk({
+        apiEndpoint: loginData.apiEndpoint!,
+        apiToken: loginData.apiToken!,
+      })
+    );
+  };
+
+  const getAliasByPeerId = (peerId: string): string => {
+    for (const [alias, id] of Object.entries(aliases!)) {
+      if (id === peerId) {
+        return alias;
+      }
+    }
+    return ''; // Return 'N/A' if alias not found for the given peerId
+  };
+
+  return (
+    <Section>
+      <h2>
+        Peers seen in the network ({peers?.announced?.length || 0}){' '}
+        <button
+          onClick={() => {
+            handleRefresh();
+          }}
+        >
+          Refresh
+        </button>
+      </h2>
+
+      <TableContainer component={Paper}>
+        <Table sx={{ minWidth: 650 }} aria-label="aliases table">
+          <TableHead>
+            <TableRow>
+              <TableCell>id</TableCell>
+              <TableCell>peerId</TableCell>
+              <TableCell>alias</TableCell>
+              <TableCell>Elegible</TableCell>
+              <TableCell>Multiaddrs</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Object.entries(peers?.announced ?? {}).map(([id, peer], key) => (
+              <TableRow key={key}>
+                <TableCell component="th" scope="row">
+                  {key}
+                </TableCell>
+                <TableCell>{peer.peerId}</TableCell>
+                <TableCell>{getAliasByPeerId(peer.peerId)}</TableCell>
+                <TableCell>
+                  {peers?.connected
+                    .some(
+                      (connectedPeer) => connectedPeer.peerId === peer.peerId
+                    )
+                    .toString()}
+                </TableCell>
+                <TableCell>{peer.multiAddr}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Section>
+  );
+}
+
+export default PeersPage;

--- a/src/sections/peers.tsx
+++ b/src/sections/peers.tsx
@@ -19,18 +19,7 @@ function PeersPage() {
   const aliases = useAppSelector((selector) => selector.sdk.aliases);
 
   useEffect(() => {
-    dispatch(
-      actionsAsync.getPeersThunk({
-        apiEndpoint: loginData.apiEndpoint!,
-        apiToken: loginData.apiToken!,
-      })
-    );
-    dispatch(
-      actionsAsync.getAliasesThunk({
-        apiEndpoint: loginData.apiEndpoint!,
-        apiToken: loginData.apiToken!,
-      })
-    );
+    handleRefresh();
   }, [loginData, dispatch]);
 
   const handleRefresh = () => {

--- a/src/sections/peers.tsx
+++ b/src/sections/peers.tsx
@@ -50,13 +50,7 @@ function PeersPage() {
     <Section>
       <h2>
         Peers seen in the network ({peers?.announced?.length || 0}){' '}
-        <button
-          onClick={() => {
-            handleRefresh();
-          }}
-        >
-          Refresh
-        </button>
+        <button onClick={handleRefresh}>Refresh</button>
       </h2>
 
       <TableContainer component={Paper}>
@@ -74,7 +68,7 @@ function PeersPage() {
             {Object.entries(peers?.announced ?? {}).map(([id, peer], key) => (
               <TableRow key={key}>
                 <TableCell component="th" scope="row">
-                  {key}
+                  {id}
                 </TableCell>
                 <TableCell>{peer.peerId}</TableCell>
                 <TableCell>{getAliasByPeerId(peer.peerId)}</TableCell>


### PR DESCRIPTION
Closes #21

### Overview
This pull Request provides peers subpage to show the announces peers with their info

Things to be added:

- [x] no styling, plain html
- [x] title: Peers seen in the network (${peers.length})
- [x] table with columns: id (from 0 up), peerId, alias, Eligible, Multiaddrs
- [x] refresh button needed at the same line as title of the page, button should be on the right

To be noted:

Elegible is currently set to show true if the peerId is connected to the current node (in both the announced and connected arrays of peers)

### Current state
![image](https://github.com/hoprnet/hopr-admin/assets/32660456/2fb011c9-d7bf-4df1-a92b-98941080bbb8)
