### PR TITLE
Fix loggin out credential bug and the # in the url error

### DIFF
--- a/src/sections/channels.tsx
+++ b/src/sections/channels.tsx
@@ -157,20 +157,28 @@ function ChannelsPage() {
   };
 
   useEffect(() => {
-    const queryParams = new URLSearchParams({
-      apiToken: loginData.apiToken!,
-      apiEndpoint: loginData.apiEndpoint!,
-    }).toString();
-
-    set_queryParams(queryParams);
-
-    if (queryParams) {
-      console.log(`queryParams: ${queryParams}`);
-      navigate(`?${queryParams}#incoming`, { replace: true });
+    if (loginData.apiEndpoint && loginData.apiToken) {
+      const queryParams = new URLSearchParams({
+        apiToken: loginData.apiToken,
+        apiEndpoint: loginData.apiEndpoint,
+      }).toString();
+      set_queryParams(queryParams);
     }
+  }, [loginData.apiToken, loginData.apiEndpoint]);
+
+  useEffect(() => {
+    const currentHash = window.location.hash;
+    const defaultHash =
+      currentHash === '#incoming' || currentHash === '#outgoing'
+        ? currentHash
+        : '#incoming';
+
+    const defaultTabIndex = defaultHash === '#outgoing' ? 1 : 0;
+    setTabIndex(defaultTabIndex);
+    handleHash(defaultTabIndex);
 
     handleRefresh();
-  }, [loginData.apiToken, loginData.apiEndpoint, navigate]);
+  }, [queryParams]);
 
   const handleRefresh = () => {
     dispatch(

--- a/src/sections/channels.tsx
+++ b/src/sections/channels.tsx
@@ -31,7 +31,7 @@ function ChannelsPage() {
   const channels = useAppSelector((selector) => selector.node.channels);
   const aliases = useAppSelector((selector) => selector.node.aliases);
   const loginData = useAppSelector((selector) => selector.auth.loginData);
-  const [tabIndex, setTabIndex] = useState(0);
+  const [tabIndex, set_tabIndex] = useState(0);
   const [closingStates, set_closingStates] = useState<
     Record<
       string,
@@ -147,7 +147,7 @@ function ChannelsPage() {
     event: React.SyntheticEvent<Element, Event>,
     newTabIndex: number
   ) => {
-    setTabIndex(newTabIndex);
+    set_tabIndex(newTabIndex);
     handleHash(newTabIndex);
   };
 
@@ -174,7 +174,7 @@ function ChannelsPage() {
         : '#incoming';
 
     const defaultTabIndex = defaultHash === '#outgoing' ? 1 : 0;
-    setTabIndex(defaultTabIndex);
+    set_tabIndex(defaultTabIndex);
     handleHash(defaultTabIndex);
 
     handleRefresh();


### PR DESCRIPTION
Closes #63

### Overview

This pull request aims to fix the bugs on the admin subpage: Channels.
Fixes expected:

- [x] When copying the url from 1 tab and going onto another, you should be placed in the same part of the application. Now you are always placed on the #incoming tab.
- [x] When logging off on the channels subpage, we get logged in right away with null credentials