### PR TITLE
Bugfix/node login

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,13 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 a {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -154,14 +154,15 @@ const LayoutEnhanced = () => {
   const apiToken = searchParams.get('apiToken');
 
   useEffect(() => {
-    if (!(apiEndpoint && apiToken)) return;
+    if (!apiEndpoint) return;
     if (loginData.apiEndpoint === apiEndpoint && loginData.apiToken === apiToken) return;
     dispatch(
       authActions.useNodeData({
         apiEndpoint,
-        apiToken,
+        apiToken: apiToken ? apiToken : '',
       }),
     );
+    if (!apiToken) return;
     dispatch(
       authActionsAsync.loginThunk({
         apiEndpoint,

--- a/src/sections/selectNode.tsx
+++ b/src/sections/selectNode.tsx
@@ -57,7 +57,8 @@ function Section1() {
     const existingItemIndex = nodesSavedLocally.findIndex((item: any) => item.apiEndpoint === loginData.apiEndpoint);
     if (existingItemIndex !== -1) set_nodesSavedLocallyChosenIndex(existingItemIndex.toString());
     const existingItem = nodesSavedLocally[existingItemIndex] as ParsedNode;
-    if (existingItem.apiToken.length > 0 && loginData.apiToken === existingItem.apiToken) set_saveApiToken(true);
+    if (existingItem && existingItem.apiToken.length > 0 && loginData.apiToken === existingItem.apiToken)
+      set_saveApiToken(true);
   }, [loginData]);
 
   useEffect(() => {

--- a/src/sections/selectNode.tsx
+++ b/src/sections/selectNode.tsx
@@ -13,35 +13,56 @@ import Checkbox from '../future-hopr-lib-components/Toggles/Checkbox';
 
 //MUI
 import CircularProgress from '@mui/material/CircularProgress';
+import { SelectChangeEvent } from '@mui/material/Select';
+
+type ParsedNode = {
+  name: string;
+  localName: string;
+  value: string;
+  apiEndpoint: string;
+  apiToken: string;
+};
 
 function Section1() {
   const dispatch = useAppDispatch();
-  const nodesSavedLocally = useAppSelector((store) => store.auth.nodes).map((node, index) => {
-    return {
-      name: node.localName ? `${node.localName} (${node.apiEndpoint})` : node.apiEndpoint,
-      localName: node.localName,
-      value: index,
-      apiEndpoint: node.apiEndpoint,
-      apiToken: node.apiToken,
-    };
-  });
+  const nodesSavedLocally = useAppSelector((store) => store.auth.nodes);
+  const [nodesSavedLocallyParsed, set_nodesSavedLocallyParsed] = useState([] as ParsedNode[]);
   const connecting = useAppSelector((store) => store.auth.status.connecting);
   const loginData = useAppSelector((store) => store.auth.loginData);
 
   const [searchParams, set_searchParams] = useSearchParams();
   const [localName, set_localName] = useState(loginData.localName ? loginData.localName : '');
+
   const [apiEndpoint, set_apiEndpoint] = useState(loginData.apiEndpoint ? loginData.apiEndpoint : '');
   const [apiToken, set_apiToken] = useState(loginData.apiToken ? loginData.apiToken : '');
   const [saveApiToken, set_saveApiToken] = useState(loginData.apiToken ? true : false);
-  const [nodesSavedLocallyChosenIndex, set_nodesSavedLocallyChosenIndex] = useState('' as number | '');
+  const [nodesSavedLocallyChosenIndex, set_nodesSavedLocallyChosenIndex] = useState('' as string);
 
   useEffect(() => {
-    // Update the Select based on loginData from the Store
-    if (!loginData.apiEndpoint) return;
-    const existingItem = nodesSavedLocally.findIndex((item: any) => item.apiEndpoint === loginData.apiEndpoint);
-    console.log(existingItem, nodesSavedLocally[existingItem]);
-    if (existingItem !== -1) set_nodesSavedLocallyChosenIndex(existingItem);
-  }, [loginData, nodesSavedLocally]);
+    console.log('nodesSavedLocally', nodesSavedLocally);
+    const parsed = nodesSavedLocally.map((node, index) => {
+      return {
+        name: node.localName ? `${node.localName} (${node.apiEndpoint})` : node.apiEndpoint,
+        localName: node.localName,
+        value: index.toString(),
+        apiEndpoint: node.apiEndpoint,
+        apiToken: node.apiToken,
+      };
+    }) as ParsedNode[];
+    set_nodesSavedLocallyParsed(parsed);
+  }, [nodesSavedLocally]);
+
+  useEffect(() => {
+    console.log('loginData', loginData);
+  }, [loginData]);
+
+  useEffect(() => {
+    console.log('nodesSavedLocallyParsed', nodesSavedLocallyParsed);
+  }, [nodesSavedLocallyParsed]);
+
+  useEffect(() => {
+    console.log('nodesSavedLocallyChosenIndex', nodesSavedLocallyChosenIndex);
+  }, [nodesSavedLocallyChosenIndex]);
 
   useEffect(() => {
     // Update the TextFields based on loginData from the Store
@@ -129,6 +150,16 @@ function Section1() {
     dispatch(authActions.clearLocalNodes());
   };
 
+  const handleSelectlocalNodes = (event: SelectChangeEvent<unknown>) => {
+    const index = event.target.value as string;
+    const chosenNode = nodesSavedLocally[parseInt(index)] as ParsedNode;
+    set_nodesSavedLocallyChosenIndex(index);
+    set_apiEndpoint(chosenNode.apiEndpoint);
+    set_apiToken(chosenNode.apiToken);
+    set_saveApiToken(chosenNode.apiToken?.length > 0);
+    set_localName(chosenNode.localName);
+  };
+
   return (
     <Section
       className="Section--selectNode"
@@ -137,27 +168,14 @@ function Section1() {
     >
       <Select
         label={'nodesSavedLocally'}
-        values={nodesSavedLocally}
+        values={nodesSavedLocallyParsed}
         disabled={nodesSavedLocally.length === 0}
         value={nodesSavedLocallyChosenIndex}
-        onChange={(event) => {
-          const index = event.target.value as number;
-          const chosenNode = nodesSavedLocally[index];
-          set_nodesSavedLocallyChosenIndex(index);
-          if (chosenNode.apiEndpoint) {
-            set_apiEndpoint(chosenNode.apiEndpoint);
-          }
-          if (chosenNode.apiToken) {
-            set_apiToken(chosenNode.apiToken);
-          }
-          if (chosenNode.localName) {
-            set_localName(chosenNode.localName);
-          }
-          if (chosenNode.apiToken) {
-            set_saveApiToken(chosenNode.apiToken?.length > 0);
-          }
-        }}
+        onChange={handleSelectlocalNodes}
         style={{ width: '100%' }}
+        renderValue={(value) => {
+          return '1';
+        }}
       />
       <button
         disabled={nodesSavedLocally.length === 0}

--- a/src/sections/selectNode.tsx
+++ b/src/sections/selectNode.tsx
@@ -35,11 +35,10 @@ function Section1() {
 
   const [apiEndpoint, set_apiEndpoint] = useState(loginData.apiEndpoint ? loginData.apiEndpoint : '');
   const [apiToken, set_apiToken] = useState(loginData.apiToken ? loginData.apiToken : '');
-  const [saveApiToken, set_saveApiToken] = useState(loginData.apiToken ? true : false);
+  const [saveApiToken, set_saveApiToken] = useState(false);
   const [nodesSavedLocallyChosenIndex, set_nodesSavedLocallyChosenIndex] = useState('' as string);
 
   useEffect(() => {
-    console.log('nodesSavedLocally', nodesSavedLocally);
     const parsed = nodesSavedLocally.map((node, index) => {
       return {
         name: node.localName ? `${node.localName} (${node.apiEndpoint})` : node.apiEndpoint,
@@ -53,16 +52,13 @@ function Section1() {
   }, [nodesSavedLocally]);
 
   useEffect(() => {
-    console.log('loginData', loginData);
+    // Update the Select based on loginData from the Store
+    if (!loginData.apiEndpoint) return;
+    const existingItemIndex = nodesSavedLocally.findIndex((item: any) => item.apiEndpoint === loginData.apiEndpoint);
+    if (existingItemIndex !== -1) set_nodesSavedLocallyChosenIndex(existingItemIndex.toString());
+    const existingItem = nodesSavedLocally[existingItemIndex] as ParsedNode;
+    if (existingItem.apiToken.length > 0 && loginData.apiToken === existingItem.apiToken) set_saveApiToken(true);
   }, [loginData]);
-
-  useEffect(() => {
-    console.log('nodesSavedLocallyParsed', nodesSavedLocallyParsed);
-  }, [nodesSavedLocallyParsed]);
-
-  useEffect(() => {
-    console.log('nodesSavedLocallyChosenIndex', nodesSavedLocallyChosenIndex);
-  }, [nodesSavedLocallyChosenIndex]);
 
   useEffect(() => {
     // Update the TextFields based on loginData from the Store
@@ -85,6 +81,7 @@ function Section1() {
     const existingItemIndex = nodesSavedLocally.findIndex(
       (item) => item.apiEndpoint === loginData.apiEndpoint && item.apiToken === loginData.apiToken,
     );
+
     if (
       existingItemIndex !== -1 &&
       nodesSavedLocally[existingItemIndex].apiToken &&

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { initialState } from './initialState';
-import { actionsAsync } from './actionsAsync';
+import { actionsAsync, createExtraReducers } from './actionsAsync';
 import { getObjectFromLocalStorage, bubbleSortObject } from '../../../utils/functions';
 
 const authSlice = createSlice({
@@ -32,7 +32,6 @@ const authSlice = createSlice({
       state.loginData.apiEndpoint = action.payload.apiEndpoint;
       state.loginData.apiToken = action.payload.apiToken;
       state.loginData.localName = localName;
-      state.status.connecting = true;
     },
     setConnected(state) {
       state.status.connecting = false;
@@ -70,6 +69,7 @@ const authSlice = createSlice({
       localStorage.removeItem('admin-ui-node-list');
     },
   },
+  extraReducers: (builder) => createExtraReducers(builder),
 });
 
 export const authActions = authSlice.actions;

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -1,4 +1,4 @@
-import { ActionReducerMapBuilder, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
+import { ActionReducerMapBuilder, createAsyncThunk } from '@reduxjs/toolkit';
 import { initialState } from './initialState';
 import {
   type AliasPayloadType,
@@ -757,13 +757,11 @@ export const createExtraReducers = (builder: ActionReducerMapBuilder<typeof init
     if (index !== -1) {
       console;
       state.messagesSent[index].status = 'error';
-      {
-        /*  @ts-ignore */
-      }
+      // prettier-ignore
+      { /*   @ts-ignore */ }
       if (typeof action.payload.status === 'string') {
-        {
-          /*  @ts-ignore */
-        }
+        // prettier-ignore
+        { /* @ts-ignore */ }
         state.messagesSent[index].error = action.payload.status;
       }
     }


### PR DESCRIPTION
Fix for:
- the select node didn't work before. When clicking on it, it didn't change.
- the `Save API Key locally (unsafe)` did mark itself when the secret wasn't saved locally.
- the `use node` button didn't use Redux fullfiled/rejected logic
- the url with apiEndpoint but without apiToken did not populate textfields
