### PR TITLE
Settings subpage

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -38,6 +38,7 @@ import HubIcon from '@mui/icons-material/Hub';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import LockIcon from '@mui/icons-material/Lock';
 import ContactPhone from '@mui/icons-material/ContactPhone';
+import SettingsPage from './sections/settings';
 
 export const applicationMap = [
   // {
@@ -80,6 +81,7 @@ export const applicationMap = [
         name: 'Configuration',
         path: 'configuration',
         icon: <SettingsIcon />,
+        element: <SettingsPage />,
         loginNeeded: 'node',
       },
     ],

--- a/src/sections/settings.tsx
+++ b/src/sections/settings.tsx
@@ -123,12 +123,13 @@ function SettingsPage() {
         >
           <TableHead>
             <TableRow>
-              <TableCell>Include Recipient</TableCell>
-              <TableCell>Strategy</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             <TableRow>
+              <TableCell>Include Recipient</TableCell>
               <TableCell>
                 False
                 <Switch
@@ -138,6 +139,9 @@ function SettingsPage() {
                 />{' '}
                 True
               </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Strategy</TableCell>
               <TableCell>
                 <Select
                   label={'Strategy'}

--- a/src/sections/settings.tsx
+++ b/src/sections/settings.tsx
@@ -156,7 +156,7 @@ function SettingsPage() {
         </Table>
       </TableContainer>
       <button
-        style={{marginTop: '1rem'}}
+        style={{ marginTop: '1rem' }}
         onClick={handleSaveSettings}
       >
         Save

--- a/src/sections/settings.tsx
+++ b/src/sections/settings.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import {
+  TableHead,
+  TableRow,
+  Table,
+  TableBody,
+  TableContainer,
+  TableCell,
+  Switch,
+  SelectChangeEvent
+} from '@mui/material';
+import { useAppDispatch, useAppSelector } from '../store';
+import Section from '../future-hopr-lib-components/Section';
+import Select from '../future-hopr-lib-components/Select';
+import { nodeActionsAsync } from '../store/slices/node';
+
+function SettingsPage() {
+  const dispatch = useAppDispatch();
+  const loginData = useAppSelector((selector) => selector.auth.loginData);
+  const settings = useAppSelector((selector) => selector.node.settings);
+  const [localSettings, set_localSettings] = useState<{
+    includeRecipient?: boolean;
+    strategy?: string;
+  }>({
+    includeRecipient: false,
+    strategy: '',
+  });
+
+  useEffect(() => {
+    if (loginData.apiEndpoint && loginData.apiToken) {
+      dispatch(
+        nodeActionsAsync.getSettingsThunk({
+          apiEndpoint: loginData.apiEndpoint,
+          apiToken: loginData.apiToken,
+        }),
+      );
+    }
+  }, [loginData]);
+
+  useEffect(() => {
+    if (settings) {
+      set_localSettings({ ...settings });
+    }
+  }, [settings]);
+
+  const handleIncludeRecipientChange = () => {
+    set_localSettings((prevState) => ({
+      ...prevState,
+      includeRecipient: !prevState.includeRecipient,
+    }));
+  };
+
+  const handleStrategyChange = (event: SelectChangeEvent<unknown>) => {
+    set_localSettings((prevState) => ({
+      ...prevState,
+      strategy: event.target.value as string,
+    }));
+  };
+
+  const getValueLabel = (value: string) => {
+    const selectedValue = strategies.find((item) => item.value === value);
+    return selectedValue ? selectedValue.name : '';
+  };
+
+  const strategies = [
+    {
+      value: 'passive',
+      name: 'Passive',
+    },
+    {
+      value: 'promiscuous',
+      name: 'Promiscuous',
+    },
+    {
+      value: 'random',
+      name: 'Random',
+    },
+  ];
+
+  const handleSaveSettings = async () => {
+    if (settings?.includeRecipient != localSettings.includeRecipient) {
+      await dispatch(
+        nodeActionsAsync.setSettingThunk({
+          apiEndpoint: loginData.apiEndpoint!,
+          apiToken: loginData.apiToken!,
+          setting: 'includeRecipient',
+          settingValue: localSettings.includeRecipient,
+        }),
+      )
+        .unwrap()
+        .catch((e) => {
+          console.log(e.error);
+        });
+    }
+
+    if (settings?.strategy != localSettings.strategy) {
+      await dispatch(
+        nodeActionsAsync.setSettingThunk({
+          apiEndpoint: loginData.apiEndpoint!,
+          apiToken: loginData.apiToken!,
+          setting: 'strategy',
+          settingValue: localSettings.strategy,
+        }),
+      )
+        .unwrap()
+        .catch((e) => {
+          console.log(e.error);
+        });
+    }
+  };
+
+  return (
+    <Section
+      className="Section--settings"
+      id="Section--settings"
+      yellow
+    >
+      <h2>Settings</h2>
+      <TableContainer>
+        <Table
+          sx={{ minWidth: 650 }}
+          aria-label="settings table"
+        >
+          <TableHead>
+            <TableRow>
+              <TableCell>Include Recipient</TableCell>
+              <TableCell>Strategy</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                False
+                <Switch
+                  checked={localSettings.includeRecipient}
+                  onChange={handleIncludeRecipientChange}
+                  color="primary"
+                />{' '}
+                True
+              </TableCell>
+              <TableCell>
+                <Select
+                  label={'Strategy'}
+                  values={strategies}
+                  disabled={!localSettings}
+                  value={localSettings.strategy}
+                  onChange={handleStrategyChange}
+                  style={{ width: '100%' }}
+                  renderValue={() => {
+                    return getValueLabel(localSettings.strategy!);
+                  }}
+                />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <button
+        style={{marginTop: '1rem'}}
+        onClick={handleSaveSettings}
+      >
+        Save
+      </button>
+    </Section>
+  );
+}
+
+export default SettingsPage;


### PR DESCRIPTION
Fixes #59

### Overview

This pull request adds the settings of the hoprd node to the admin UI, allowing changes easily.

#### The following functionalities are to be expected:

- [x] Settings subpage
- [x] table showing following entries under name column {
"includeRecipient"
"strategy"
}
- [x] Column with selects/dropdowns with all options possible per setting
- [x] Save button below the table to change settings which are chosen
- [x] Current settings in Redux
- [x] Changes to settings done before saving should be kept in useState in the Section
- [x] onClick of Save button, the Redux action should send the new settings to the node and on success, save them to Redux store