### PR TITLE
Subpage: Metrics

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,6 +17,7 @@ import MessagesPage from './sections/messages';
 import PeersPage from './sections/peers';
 import TicketsPage from './sections/tickets';
 import ChannelsPage from './sections/channels';
+import MetricsPage from './sections/metrics';
 import SettingsPage from './sections/settings';
 
 // Layout
@@ -42,6 +43,7 @@ import ContactPhone from '@mui/icons-material/ContactPhone';
 import NodeIcon from '@mui/icons-material/Router';
 import NetworkingIcon from '@mui/icons-material/Diversity3';
 import DevelopIcon from '@mui/icons-material/Code';
+import BarChartIcon from '@mui/icons-material/BarChart';
 
 export type ApplicationMapType = {
   groupName: string;
@@ -92,6 +94,13 @@ export const applicationMap: ApplicationMapType = [
         path: 'tickets',
         icon: <ConfirmationNumberIcon />,
         element: <TicketsPage />,
+        loginNeeded: 'node',
+      },
+      {
+        name: 'Metrics',
+        path: 'metrics',
+        icon: <BarChartIcon />,
+        element: <MetricsPage />,
         loginNeeded: 'node',
       },
       {

--- a/src/sections/metrics.tsx
+++ b/src/sections/metrics.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import Section from '../future-hopr-lib-components/Section';
+import { useAppDispatch, useAppSelector } from '../store';
+import { actionsAsync } from '../store/slices/node/actionsAsync';
+
+function MetricsPage() {
+  const metrics = useAppSelector((selector) => selector.node.metrics);
+  const loginData = useAppSelector((selector) => selector.auth.loginData);
+  const {
+    apiEndpoint,
+    apiToken,
+  } = loginData;
+
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (apiEndpoint && apiToken) {
+      dispatch(
+        actionsAsync.getPrometheusMetricsThunk({
+          apiEndpoint,
+          apiToken,
+        }),
+      );
+    }
+  }, [apiEndpoint, apiToken]);
+
+  return (
+    <Section yellow>
+      <h2>Metrics</h2>
+      <pre>{metrics}</pre>
+    </Section>
+  );
+}
+
+export default MetricsPage;


### PR DESCRIPTION
### Closes: #37

### Tasks:
- [x] Create metrics subpage.
- [x] Show metrics from redux and get them with `getPrometheusMetricsThunk`.

### What's missing?
A way to read the prometheus string in exposition format to properly show metrics to the users and not a big string within a `<pre>` tag

### Metrics in a better format:
```
Metric: connect_counter_client_relayed_packets
Description: Number of relayed packets (TURN client)
Type: counter
Value: 11048

Metric: connect_counter_direct_packets
Description: Number of directly sent packets (TCP)
Type: counter
Value: 725248

Metric: connect_counter_failed_conns
Description: Number of failed connection attempts
Type: counter
Value: 1247

Metric: connect_counter_failed_direct_dials
Description: Number of failed direct dials
Type: counter
Value: 8262

Metric: connect_counter_failed_relay_reqs
Description: Number of failed incoming relay requests
Type: counter
Value: 0

Metric: connect_counter_failed_relayed_dials
Description: Number of failed relayed dials
Type: counter
Value: 1263

Metric: connect_counter_relay_reconnects
Description: Number of re-established relayed connections
Type: counter
Value: 0

Metric: connect_counter_server_relayed_packets
Description: Number of relayed packets (TURN server)
Type: counter
Value: 0

Metric: connect_counter_successful_conns
Description: Number of successful connection attempts
Type: counter
Value: 136

Metric: connect_counter_successful_direct_dials
Description: Number of successful direct dials
Type: counter
Value: 2892

Metric: connect_counter_successful_relay_reqs
Description: Number of successful incoming relay requests
Type: counter
Value: 7

Metric: connect_counter_successful_relayed_dials
Description: Number of successful relayed dials
Type: counter
Value: 120

Metric: connect_counter_tcp_stun_requests
Description: Number of TCP STUN requests
Type: counter
Value: 0

Metric: connect_counter_udp_stun_requests
Description: Number of UDP STUN requests
Type: counter
Value: 1248

Metric: connect_counter_webrtc_packets
Description: Number of directly sent packets (WebRTC)
Type: counter
Value: 195

Metric: connect_gauge_conns_to_relays
Description: Number of connections to relays
Type: gauge
Value: 4

Metric: connect_gauge_evicted_relayed_conns
Description: Number of inactive relayed connections which were last removed from the relay state
Type: gauge
Value: 0

Metric: connect_gauge_node_is_exposed
Description: Shows whether a node believes to run on an exposed host
Type: gauge
Value: 1

Metric: connect_gauge_relayed_conns
Description: Number of currently relayed connections
Type: gauge
Value: 0

Metric: connect_gauge_used_relays
Description: Number of relays used
Type: gauge
Value: 1
```