### PR TITLE
Reconnect ws on page refresh

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -203,6 +203,13 @@ const LayoutEnhanced = () => {
         apiEndpoint,
       }),
     );
+    dispatch(nodeActions.initializeMessagesWebsocket());
+    dispatch(nodeActions.initializeLogsWebsocket());
+
+    return () => {
+      dispatch(nodeActions.closeLogsWebsocket());
+      dispatch(nodeActions.closeMessagesWebsocket());
+    };
   }, [apiEndpoint, apiToken]);
 
   return (

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -34,11 +34,11 @@ const nodeSlice = createSlice({
       state.logs.push(action.payload);
     },
     // handle ws state
-    updateMessagesWebsocketStatus(state, action: PayloadAction<boolean>) {
-      state.messagesWebsocketConnected = action.payload;
+    updateMessagesWebsocketStatus(state, action: PayloadAction<typeof initialState.messagesWebsocketStatus>) {
+      state.messagesWebsocketStatus = action.payload;
     },
-    updateLogsWebsocketStatus(state, action: PayloadAction<boolean>) {
-      state.logsWebsocketConnected = action.payload;
+    updateLogsWebsocketStatus(state, action: PayloadAction<typeof initialState.messagesWebsocketStatus>) {
+      state.logsWebsocketStatus = action.payload;
     },
     // user actions to open and close ws
     initializeMessagesWebsocket() {

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -23,6 +23,8 @@ type Message = {
   challenge?: string;
 };
 
+type WebsocketConnectionStatus = 'connecting' | 'connected' | 'error' | null
+
 type InitialState = {
   info: GetInfoResponseType | null;
   status: {
@@ -55,8 +57,8 @@ type InitialState = {
   transactions: string[];
   pings: (PingNodeResponseType & { peerId: string })[];
   metrics: string | null;
-  messagesWebsocketConnected: boolean;
-  logsWebsocketConnected: boolean;
+  messagesWebsocketStatus: WebsocketConnectionStatus;
+  logsWebsocketStatus: WebsocketConnectionStatus;
 };
 
 export const initialState: InitialState = {
@@ -93,6 +95,6 @@ export const initialState: InitialState = {
   transactions: [],
   pings: [],
   metrics: null,
-  messagesWebsocketConnected: false,
-  logsWebsocketConnected: false,
+  messagesWebsocketStatus: null,
+  logsWebsocketStatus: null,
 };

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -23,7 +23,7 @@ type Message = {
   challenge?: string;
 };
 
-type WebsocketConnectionStatus = 'connecting' | 'connected' | 'error' | null
+type WebsocketConnectionStatus = 'connecting' | 'connected' | 'error' | null;
 
 type InitialState = {
   info: GetInfoResponseType | null;

--- a/src/store/slices/node/websocketMiddleware.ts
+++ b/src/store/slices/node/websocketMiddleware.ts
@@ -1,5 +1,6 @@
 import { utils } from '@hoprnet/hopr-sdk';
 import { Middleware, PayloadAction, nanoid } from '@reduxjs/toolkit';
+import { initialState as nodeInitialState } from '../node/initialState';
 import { initialState } from '../auth/initialState';
 import { nodeActions } from './index';
 import readStreamEvent from '../../../utils/readStreamEvent';
@@ -19,6 +20,7 @@ const { WebsocketHelper } = utils;
 
 type LocalRootState = {
   auth: typeof initialState;
+  node: typeof nodeInitialState
 };
 
 const websocketMiddleware: Middleware<object, LocalRootState> = ({
@@ -30,21 +32,30 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
 
   return (next) => (action: PayloadAction) => {
     if (action.type === initializeMessagesWebsocket.type) {
+      
       // start websocket connection
       const {
         apiEndpoint,
         apiToken,
       } = getState().auth.loginData;
+      const messagesWebsocketStatus = getState().node.messagesWebsocketStatus;
       if (apiEndpoint && apiToken) {
         try {
+          // check if connection is being established
+          if (messagesWebsocketStatus === 'connecting') return
+          // close previous ws before opening new one
+          if (messagesWebsocket) {
+            messagesWebsocket.close()
+          }
+          dispatch(updateMessagesWebsocketStatus('connecting'))
           messagesWebsocket = new WebsocketHelper({
             apiEndpoint,
             apiToken,
             onOpen: () => {
-              dispatch(updateMessagesWebsocketStatus(true));
+              dispatch(updateMessagesWebsocketStatus('connected'));
             },
             onClose: () => {
-              dispatch(updateMessagesWebsocketStatus(false));
+              dispatch(updateMessagesWebsocketStatus(null));
             },
             onMessage: (message) => {
               dispatch(
@@ -58,31 +69,38 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
             },
           });
         } catch (e) {
-          console.log(e);
-          dispatch(updateMessagesWebsocketStatus(false));
+          dispatch(updateMessagesWebsocketStatus('error'));
         }
       }
     } else if (action.type === closeMessagesWebsocket.type) {
       // close messages websocket
       messagesWebsocket?.close();
-      dispatch(updateMessagesWebsocketStatus(false));
+      dispatch(updateMessagesWebsocketStatus(null));
     } else if (action.type === initializeLogsWebsocket.type) {
       const {
         apiEndpoint,
         apiToken,
       } = getState().auth.loginData;
+      const logsWebsocketStatus = getState().node.logsWebsocketStatus;
       if (apiEndpoint && apiToken) {
         try {
+          // check if connection is being established
+          if (logsWebsocketStatus === 'connecting') return
+          // close previous ws before opening new one
+          if (logsWebsocket) {
+            logsWebsocket.close()
+          }
+          dispatch(updateLogsWebsocketStatus('connecting'))
           logsWebsocket = new WebsocketHelper({
             apiEndpoint,
             apiToken,
             decodeMessage: false,
             path: '/api/v2/node/stream/websocket/',
             onOpen: () => {
-              dispatch(updateLogsWebsocketStatus(true));
+              dispatch(updateLogsWebsocketStatus('connected'));
             },
             onClose: () => {
-              dispatch(updateLogsWebsocketStatus(false));
+              dispatch(updateLogsWebsocketStatus(null));
             },
             onMessage: (message) => {
               const log = readStreamEvent(message);
@@ -92,14 +110,13 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
             },
           });
         } catch (e) {
-          console.log(e);
-          dispatch(updateLogsWebsocketStatus(false));
+          dispatch(updateLogsWebsocketStatus('error'));
         }
       }
     } else if (action.type === closeLogsWebsocket.type) {
       // close logs websocket
       logsWebsocket?.close();
-      dispatch(updateLogsWebsocketStatus(false));
+      dispatch(updateLogsWebsocketStatus(null));
     } else {
       return next(action);
     }

--- a/src/store/slices/node/websocketMiddleware.ts
+++ b/src/store/slices/node/websocketMiddleware.ts
@@ -20,7 +20,7 @@ const { WebsocketHelper } = utils;
 
 type LocalRootState = {
   auth: typeof initialState;
-  node: typeof nodeInitialState
+  node: typeof nodeInitialState;
 };
 
 const websocketMiddleware: Middleware<object, LocalRootState> = ({
@@ -32,7 +32,6 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
 
   return (next) => (action: PayloadAction) => {
     if (action.type === initializeMessagesWebsocket.type) {
-      
       // start websocket connection
       const {
         apiEndpoint,
@@ -42,12 +41,12 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
       if (apiEndpoint && apiToken) {
         try {
           // check if connection is being established
-          if (messagesWebsocketStatus === 'connecting') return
+          if (messagesWebsocketStatus === 'connecting') return;
           // close previous ws before opening new one
           if (messagesWebsocket) {
-            messagesWebsocket.close()
+            messagesWebsocket.close();
           }
-          dispatch(updateMessagesWebsocketStatus('connecting'))
+          dispatch(updateMessagesWebsocketStatus('connecting'));
           messagesWebsocket = new WebsocketHelper({
             apiEndpoint,
             apiToken,
@@ -85,12 +84,12 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
       if (apiEndpoint && apiToken) {
         try {
           // check if connection is being established
-          if (logsWebsocketStatus === 'connecting') return
+          if (logsWebsocketStatus === 'connecting') return;
           // close previous ws before opening new one
           if (logsWebsocket) {
-            logsWebsocket.close()
+            logsWebsocket.close();
           }
-          dispatch(updateLogsWebsocketStatus('connecting'))
+          dispatch(updateLogsWebsocketStatus('connecting'));
           logsWebsocket = new WebsocketHelper({
             apiEndpoint,
             apiToken,


### PR DESCRIPTION
fixes #65 

## overview
after refreshing the page ws connections are re-established.

### redux changes
now the ws status is not determined by a boolean but by a string type union, giving us the flexibility to add more statuses if needed but right now we can determine if a ws is connecting | connected | error