### PR TITLE
Add Safe transaction history

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -24,6 +24,7 @@ import AddNode from './steps/install-node/addNode';
 import SelectNodeType from './steps/install-node/selectNodeType';
 import WrapperPage from './sections/wrapper';
 import XdaiToNodePage from './steps/xdaiToNode';
+import SafeTransactionHistoryPage from './sections/safe-transaction-history';
 
 // Layout
 import Layout from './future-hopr-lib-components/Layout';
@@ -55,6 +56,7 @@ import AddBoxIcon from '@mui/icons-material/AddBox';
 import DockerInstallation from './steps/install-node/dockerInstallation';
 import NodeAddress from './steps/install-node/nodeAddress';
 import PaidIcon from '@mui/icons-material/Paid';
+import ReceiptIcon from '@mui/icons-material/Receipt';
 
 export type ApplicationMapType = {
   groupName: string;
@@ -189,6 +191,13 @@ export const applicationMap: ApplicationMapType = [
         path: 'safe/staking',
         icon: <SavingsIcon />,
         element: <SafeStakingPage />,
+        loginNeeded: 'web3',
+      },
+      {
+        name: 'Transaction history',
+        path: 'safe/transaction-history',
+        icon: <ReceiptIcon />,
+        element: <SafeTransactionHistoryPage />,
         loginNeeded: 'web3',
       },
       {

--- a/src/sections/safe-transaction-history.tsx
+++ b/src/sections/safe-transaction-history.tsx
@@ -136,6 +136,29 @@ function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWit
   const { transaction } = props;
   const [open, set_open] = useState(false);
 
+  const getType = (transaction: SafeMultisigTransactionWithTransfersResponse) => {
+    if (transaction.dataDecoded) {
+      const decodedData = getDecodedData(transaction);
+      return typeof decodedData === 'string' ? decodedData : decodedData?.method;
+    } else if (BigInt(transaction.value)) {
+      return 'Sent';
+    } else {
+      return 'Rejection';
+    }
+  };
+
+  const getDecodedData = (transaction: SafeMultisigTransactionWithTransfersResponse) => {
+    if (typeof transaction.dataDecoded === 'string') {
+      return transaction.dataDecoded;
+    } else if (typeof transaction.dataDecoded === 'object') {
+      const transactionData = transaction.dataDecoded as unknown as {
+        method: string;
+        parameters: { name: string; type: string; value: string }[];
+      };
+      return transactionData;
+    }
+  };
+
   return (
     <>
       <TableRow>
@@ -145,7 +168,7 @@ function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWit
         >
           {transaction.nonce}
         </TableCell>
-        <TableCell align="right">{BigInt(transaction.value) ? 'Sent' : 'Rejection'}</TableCell>
+        <TableCell align="right">{getType(transaction)}</TableCell>
         <TableCell align="right"> {formatEther(BigInt(transaction.value))}</TableCell>
         <TableCell align="right">{transaction.executionDate}</TableCell>
         <TableCell align="right">{transaction.isExecuted ? 'Success' : 'Not executed'}</TableCell>

--- a/src/sections/safe-transaction-history.tsx
+++ b/src/sections/safe-transaction-history.tsx
@@ -1,0 +1,322 @@
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import {
+  Box,
+  Collapse,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import { AllTransactionsListResponse, EthereumTxWithTransfersResponse, SafeModuleTransactionWithTransfersResponse, SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit'
+import { useEffect, useState } from 'react';
+import { useSigner } from '../hooks';
+import { useAppDispatch, useAppSelector } from '../store';
+import { safeActionsAsync } from '../store/slices/safe';
+import { formatEther, parseEther } from 'viem';
+
+function EthereumTransactionRow(props: { transaction: EthereumTxWithTransfersResponse }) {
+  const { transaction } = props;
+  const [open, set_open] = useState(false);
+
+  return (
+    <>
+      <TableRow>
+        <TableCell
+          component="th"
+          scope="row"
+        ></TableCell>
+        <TableCell align="right">Received</TableCell>
+        <TableCell align="right">
+          {transaction.transfers[0] ? formatEther(BigInt(transaction.transfers[0].value)) : ''}
+        </TableCell>
+        <TableCell align="right">{transaction.executionDate}</TableCell>
+        <TableCell align="right">{transaction.txType}</TableCell>
+        <TableCell>
+          <IconButton
+            aria-label="expand row"
+            size="small"
+            onClick={() => set_open(!open)}
+          >
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>
+          <Collapse
+            in={open}
+            timeout="auto"
+            unmountOnExit
+          >
+            <Box>
+              <Typography
+                variant="h6"
+                gutterBottom
+                component="div"
+              >
+                Description
+              </Typography>
+              <Table
+                size="small"
+                aria-label="purchases"
+              >
+                {/* <TableHead>
+                  <TableRow>
+                    <TableCell>Date</TableCell>
+                    <TableCell>Customer</TableCell>
+                    <TableCell align="right">Amount</TableCell>
+                    <TableCell align="right">Total price ($)</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {row.history.map((historyRow) => (
+                    <TableRow key={historyRow.date}>
+                      <TableCell
+                        component="th"
+                        scope="row"
+                      >
+                        {historyRow.date}
+                      </TableCell>
+                      <TableCell>{historyRow.customerId}</TableCell>
+                      <TableCell align="right">{historyRow.amount}</TableCell>
+                      <TableCell align="right">{Math.round(historyRow.amount * row.price * 100) / 100}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody> */}
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
+
+function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWithTransfersResponse }) {
+  const { transaction } = props;
+  const [open, set_open] = useState(false);
+
+  return (
+    <>
+      <TableRow>
+        <TableCell
+          component="th"
+          scope="row"
+        >
+          {transaction.nonce}
+        </TableCell>
+        <TableCell align="right">{BigInt(transaction.value) ? 'Sent' : 'Rejection'}</TableCell>
+        <TableCell align="right"> {formatEther(BigInt(transaction.value))}</TableCell>
+        <TableCell align="right">{transaction.executionDate}</TableCell>
+        <TableCell align="right">{transaction.isExecuted ? 'SUCCESS' : 'NOT EXECUTED'}</TableCell>
+        <TableCell>
+          <IconButton
+            aria-label="expand row"
+            size="small"
+            onClick={() => set_open(!open)}
+          >
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>
+          <Collapse
+            in={open}
+            timeout="auto"
+            unmountOnExit
+          >
+            <Box>
+              <Typography
+                variant="h6"
+                gutterBottom
+                component="div"
+              >
+                Description
+              </Typography>
+              <Table
+                size="small"
+                aria-label="purchases"
+              >
+                {/* <TableHead>
+                  <TableRow>
+                    <TableCell>Date</TableCell>
+                    <TableCell>Customer</TableCell>
+                    <TableCell align="right">Amount</TableCell>
+                    <TableCell align="right">Total price ($)</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {row.history.map((historyRow) => (
+                    <TableRow key={historyRow.date}>
+                      <TableCell
+                        component="th"
+                        scope="row"
+                      >
+                        {historyRow.date}
+                      </TableCell>
+                      <TableCell>{historyRow.customerId}</TableCell>
+                      <TableCell align="right">{historyRow.amount}</TableCell>
+                      <TableCell align="right">{Math.round(historyRow.amount * row.price * 100) / 100}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody> */}
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
+
+function ModuleTransactionRow(props: { transaction: SafeModuleTransactionWithTransfersResponse }) {
+  const { transaction } = props;
+  const [open, set_open] = useState(false);
+
+  return (
+    <>
+      <TableRow>
+        <TableCell
+          component="th"
+          scope="row"
+        >
+          {}
+        </TableCell>
+        <TableCell align="right">{transaction.to}</TableCell>
+        <TableCell align="right">{transaction.executionDate}</TableCell>
+        <TableCell align="right">{transaction.blockNumber}</TableCell>
+        <TableCell align="right">{transaction.txType}</TableCell>
+        <TableCell>
+          <IconButton
+            aria-label="expand row"
+            size="small"
+            onClick={() => set_open(!open)}
+          >
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>
+          <Collapse
+            in={open}
+            timeout="auto"
+            unmountOnExit
+          >
+            <Box>
+              <Typography
+                variant="h6"
+                gutterBottom
+                component="div"
+              >
+                Description
+              </Typography>
+              <Table
+                size="small"
+                aria-label="purchases"
+              >
+                {/* <TableHead>
+                  <TableRow>
+                    <TableCell>Date</TableCell>
+                    <TableCell>Customer</TableCell>
+                    <TableCell align="right">Amount</TableCell>
+                    <TableCell align="right">Total price ($)</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {row.history.map((historyRow) => (
+                    <TableRow key={historyRow.date}>
+                      <TableCell
+                        component="th"
+                        scope="row"
+                      >
+                        {historyRow.date}
+                      </TableCell>
+                      <TableCell>{historyRow.customerId}</TableCell>
+                      <TableCell align="right">{historyRow.amount}</TableCell>
+                      <TableCell align="right">{Math.round(historyRow.amount * row.price * 100) / 100}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody> */}
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
+
+function TransactionHistoryRow(props: { transaction: AllTransactionsListResponse['results'][0] }) {
+  const { transaction } = props;
+
+  const getTransactionTypeRow = (transaction: AllTransactionsListResponse['results'][0]) => {
+    if (transaction.txType === 'ETHEREUM_TRANSACTION') {
+      return <EthereumTransactionRow transaction={transaction} />;
+    } else if (transaction.txType === 'MULTISIG_TRANSACTION') {
+      return <MultisigTransactionRow transaction={transaction} />;
+    } else if (transaction.txType === 'MODULE_TRANSACTION') {
+      return <ModuleTransactionRow transaction={transaction} />;
+    }
+  };
+
+  return getTransactionTypeRow(transaction);
+}
+
+export default function SafeTransactionHistoryPage() {
+  const dispatch = useAppDispatch();
+  const safeTransactions = useAppSelector((state) => state.safe.safeTransactions);
+  const selectedSafeAddress = useAppSelector((state) => state.safe.selectedSafeAddress);
+  const { signer } = useSigner();
+
+  const fetchAllSafeTransaction = () => {
+    if (signer && selectedSafeAddress) {
+      dispatch(
+        safeActionsAsync.getAllSafeTransactionsThunk({
+          signer,
+          safeAddress: selectedSafeAddress,
+        }),
+      );
+    }
+  };
+
+  useEffect(() => {
+    fetchAllSafeTransaction();
+  }, [signer, selectedSafeAddress]);
+
+  if (!selectedSafeAddress) {
+    return <div>connect to safe</div>;
+  }
+
+  return (
+    <TableContainer component={Paper}>
+      <Table aria-label="safe transaction history">
+        <TableHead>
+          <TableRow>
+            <TableCell>Nonce</TableCell>
+            <TableCell align="right">Type</TableCell>
+            <TableCell align="right">Amount</TableCell>
+            <TableCell align="right">Time</TableCell>
+            <TableCell align="right">Status</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {safeTransactions?.results.map((transaction, key) => (
+            <TransactionHistoryRow
+              transaction={transaction}
+              key={key}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/sections/safe-transaction-history.tsx
+++ b/src/sections/safe-transaction-history.tsx
@@ -1,5 +1,7 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
   Box,
   Collapse,
@@ -32,9 +34,20 @@ const StyledCollapsibleCell = styled(TableCell)`
 
 const StyledBox = styled(Box)`
   margin: 1;
-  margin-left: auto;
   display: flex;
   justify-content: space-evenly;
+`;
+
+const StyledTransactionHashWithIcon = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  & svg {
+    align-self: flex-end;
+    height: 16px;
+    width: 16px;
+  }
 `;
 
 const GnosisLink = styled.a`
@@ -49,7 +62,7 @@ const GnosisLink = styled.a`
   }
 `;
 
-const GNOSIS_BASE_URL = '';
+const GNOSIS_BASE_URL = 'https://gnosisscan.io';
 
 function EthereumTransactionRow(props: { transaction: EthereumTxWithTransfersResponse }) {
   const { transaction } = props;
@@ -156,11 +169,39 @@ function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWit
             <StyledBox>
               <List>
                 <p>Created: {transaction.submissionDate}</p>
-                <p>To: {transaction.value}</p>
-                <p>Safe hash: {truncateEthereumAddress(transaction.safeTxHash)}</p>{' '}
+                <StyledTransactionHashWithIcon>
+                  <span>To: {truncateEthereumAddress(transaction.to)}</span>
+                  <GnosisLink
+                    href={`${GNOSIS_BASE_URL}/address/${transaction.to}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <OpenInNewIcon />
+                  </GnosisLink>
+                </StyledTransactionHashWithIcon>
+                <StyledTransactionHashWithIcon>
+                  <span>Safe hash: {truncateEthereumAddress(transaction.safeTxHash)}</span>
+                  <IconButton
+                    onClick={() => {
+                      navigator.clipboard.writeText(transaction.safeTxHash);
+                    }}
+                  >
+                    {' '}
+                    <ContentCopyIcon />
+                  </IconButton>
+                </StyledTransactionHashWithIcon>
                 {transaction.isExecuted && (
                   <>
-                    <p>Transaction hash: {truncateEthereumAddress(transaction.transactionHash)}</p>
+                    <StyledTransactionHashWithIcon>
+                      <span>Transaction hash: {truncateEthereumAddress(transaction.transactionHash)}</span>
+                      <GnosisLink
+                        href={`${GNOSIS_BASE_URL}/tx/${transaction.transactionHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <OpenInNewIcon />
+                      </GnosisLink>
+                    </StyledTransactionHashWithIcon>
                     <p>Executed: {transaction.executionDate}</p>
                   </>
                 )}
@@ -173,12 +214,30 @@ function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWit
               <List>
                 <h4>Confirmations {`(${transaction.confirmations?.length}/${transaction.confirmationsRequired})`}</h4>
                 {transaction.confirmations?.map((confirmation) => (
-                  <p key={confirmation.owner}>- {confirmation.owner}</p>
+                  <StyledTransactionHashWithIcon key={confirmation.owner}>
+                    <span>- {truncateEthereumAddress(confirmation.owner)}</span>
+                    <GnosisLink
+                      href={`${GNOSIS_BASE_URL}/address/${confirmation.owner}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <OpenInNewIcon />
+                    </GnosisLink>
+                  </StyledTransactionHashWithIcon>
                 ))}
                 {transaction.executor && (
                   <>
                     <h4>Executor</h4>
-                    <p>{transaction.executor}</p>
+                    <StyledTransactionHashWithIcon>
+                      <span>- {truncateEthereumAddress(transaction.executor)}</span>
+                      <GnosisLink
+                        href={`${GNOSIS_BASE_URL}/address/${transaction.executor}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <OpenInNewIcon />
+                      </GnosisLink>
+                    </StyledTransactionHashWithIcon>
                   </>
                 )}
               </List>
@@ -214,53 +273,6 @@ function ModuleTransactionRow(props: { transaction: SafeModuleTransactionWithTra
             {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
           </IconButton>
         </TableCell>
-      </TableRow>
-      <TableRow>
-        <StyledCollapsibleCell>
-          <Collapse
-            in={open}
-            timeout="auto"
-            unmountOnExit
-          >
-            <StyledBox>
-              <Typography
-                variant="h6"
-                gutterBottom
-                component="div"
-              >
-                Description
-              </Typography>
-              <Table
-                size="small"
-                aria-label="purchases"
-              >
-                {/* <TableHead>
-                  <TableRow>
-                    <TableCell>Date</TableCell>
-                    <TableCell>Customer</TableCell>
-                    <TableCell align="right">Amount</TableCell>
-                    <TableCell align="right">Total price ($)</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {row.history.map((historyRow) => (
-                    <TableRow key={historyRow.date}>
-                      <TableCell
-                        component="th"
-                        scope="row"
-                      >
-                        {historyRow.date}
-                      </TableCell>
-                      <TableCell>{historyRow.customerId}</TableCell>
-                      <TableCell align="right">{historyRow.amount}</TableCell>
-                      <TableCell align="right">{Math.round(historyRow.amount * row.price * 100) / 100}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody> */}
-              </Table>
-            </StyledBox>
-          </Collapse>
-        </StyledCollapsibleCell>
       </TableRow>
     </>
   );

--- a/src/sections/safe-transaction-history.tsx
+++ b/src/sections/safe-transaction-history.tsx
@@ -3,7 +3,9 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import {
   Box,
   Collapse,
+  Divider,
   IconButton,
+  List,
   Paper,
   Table,
   TableBody,
@@ -18,7 +20,36 @@ import { useEffect, useState } from 'react';
 import { useSigner } from '../hooks';
 import { useAppDispatch, useAppSelector } from '../store';
 import { safeActionsAsync } from '../store/slices/safe';
-import { formatEther, parseEther } from 'viem';
+import { formatEther } from 'viem';
+import styled from '@emotion/styled';
+import { truncateEthereumAddress } from '../utils/helpers';
+import Section from '../future-hopr-lib-components/Section';
+
+const StyledCollapsibleCell = styled(TableCell)`
+  padding-bottom: 0;
+  padding-top: 0;
+`;
+
+const StyledBox = styled(Box)`
+  margin: 1;
+  margin-left: auto;
+  display: flex;
+  justify-content: space-evenly;
+`;
+
+const GnosisLink = styled.a`
+  display: inline-flex;
+  gap: 2px;
+  text-decoration: underline;
+
+  & svg {
+    align-self: flex-end;
+    height: 16px;
+    width: 16px;
+  }
+`;
+
+const GNOSIS_BASE_URL = '';
 
 function EthereumTransactionRow(props: { transaction: EthereumTxWithTransfersResponse }) {
   const { transaction } = props;
@@ -36,7 +67,7 @@ function EthereumTransactionRow(props: { transaction: EthereumTxWithTransfersRes
           {transaction.transfers[0] ? formatEther(BigInt(transaction.transfers[0].value)) : ''}
         </TableCell>
         <TableCell align="right">{transaction.executionDate}</TableCell>
-        <TableCell align="right">{transaction.txType}</TableCell>
+        <TableCell align="right">Success</TableCell>
         <TableCell>
           <IconButton
             aria-label="expand row"
@@ -48,51 +79,41 @@ function EthereumTransactionRow(props: { transaction: EthereumTxWithTransfersRes
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell>
+        <StyledCollapsibleCell colSpan={6}>
           <Collapse
             in={open}
             timeout="auto"
             unmountOnExit
           >
-            <Box>
-              <Typography
-                variant="h6"
-                gutterBottom
-                component="div"
-              >
-                Description
-              </Typography>
-              <Table
-                size="small"
-                aria-label="purchases"
-              >
-                {/* <TableHead>
+            <StyledBox>
+              <Table size="small">
+                <TableHead>
                   <TableRow>
-                    <TableCell>Date</TableCell>
-                    <TableCell>Customer</TableCell>
+                    <TableCell>From</TableCell>
+                    <TableCell>To</TableCell>
                     <TableCell align="right">Amount</TableCell>
-                    <TableCell align="right">Total price ($)</TableCell>
+                    <TableCell align="right">Hash</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {row.history.map((historyRow) => (
-                    <TableRow key={historyRow.date}>
+                  {transaction.transfers.map((transfer) => (
+                    <TableRow key={transfer.transactionHash}>
                       <TableCell
                         component="th"
                         scope="row"
                       >
-                        {historyRow.date}
+                        {truncateEthereumAddress(transfer.from)}
                       </TableCell>
-                      <TableCell>{historyRow.customerId}</TableCell>
-                      <TableCell align="right">{historyRow.amount}</TableCell>
-                      <TableCell align="right">{Math.round(historyRow.amount * row.price * 100) / 100}</TableCell>
+                      <TableCell>{truncateEthereumAddress(transfer.to)}</TableCell>
+                      <TableCell align="right">{formatEther(BigInt(transfer.value))}</TableCell>
+                      <TableCell align="right">{truncateEthereumAddress(transfer.transactionHash)}</TableCell>
                     </TableRow>
                   ))}
-                </TableBody> */}
+                </TableBody>
               </Table>
-            </Box>
+            </StyledBox>
           </Collapse>
-        </TableCell>
+        </StyledCollapsibleCell>
       </TableRow>
     </>
   );
@@ -114,7 +135,7 @@ function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWit
         <TableCell align="right">{BigInt(transaction.value) ? 'Sent' : 'Rejection'}</TableCell>
         <TableCell align="right"> {formatEther(BigInt(transaction.value))}</TableCell>
         <TableCell align="right">{transaction.executionDate}</TableCell>
-        <TableCell align="right">{transaction.isExecuted ? 'SUCCESS' : 'NOT EXECUTED'}</TableCell>
+        <TableCell align="right">{transaction.isExecuted ? 'Success' : 'Not executed'}</TableCell>
         <TableCell>
           <IconButton
             aria-label="expand row"
@@ -126,51 +147,44 @@ function MultisigTransactionRow(props: { transaction: SafeMultisigTransactionWit
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell>
+        <StyledCollapsibleCell colSpan={6}>
           <Collapse
             in={open}
             timeout="auto"
             unmountOnExit
           >
-            <Box>
-              <Typography
-                variant="h6"
-                gutterBottom
-                component="div"
-              >
-                Description
-              </Typography>
-              <Table
-                size="small"
-                aria-label="purchases"
-              >
-                {/* <TableHead>
-                  <TableRow>
-                    <TableCell>Date</TableCell>
-                    <TableCell>Customer</TableCell>
-                    <TableCell align="right">Amount</TableCell>
-                    <TableCell align="right">Total price ($)</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {row.history.map((historyRow) => (
-                    <TableRow key={historyRow.date}>
-                      <TableCell
-                        component="th"
-                        scope="row"
-                      >
-                        {historyRow.date}
-                      </TableCell>
-                      <TableCell>{historyRow.customerId}</TableCell>
-                      <TableCell align="right">{historyRow.amount}</TableCell>
-                      <TableCell align="right">{Math.round(historyRow.amount * row.price * 100) / 100}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody> */}
-              </Table>
-            </Box>
+            <StyledBox>
+              <List>
+                <p>Created: {transaction.submissionDate}</p>
+                <p>To: {transaction.value}</p>
+                <p>Safe hash: {truncateEthereumAddress(transaction.safeTxHash)}</p>{' '}
+                {transaction.isExecuted && (
+                  <>
+                    <p>Transaction hash: {truncateEthereumAddress(transaction.transactionHash)}</p>
+                    <p>Executed: {transaction.executionDate}</p>
+                  </>
+                )}
+              </List>
+              <Divider
+                orientation="vertical"
+                variant="middle"
+                flexItem
+              />
+              <List>
+                <h4>Confirmations {`(${transaction.confirmations?.length}/${transaction.confirmationsRequired})`}</h4>
+                {transaction.confirmations?.map((confirmation) => (
+                  <p key={confirmation.owner}>- {confirmation.owner}</p>
+                ))}
+                {transaction.executor && (
+                  <>
+                    <h4>Executor</h4>
+                    <p>{transaction.executor}</p>
+                  </>
+                )}
+              </List>
+            </StyledBox>
           </Collapse>
-        </TableCell>
+        </StyledCollapsibleCell>
       </TableRow>
     </>
   );
@@ -186,12 +200,10 @@ function ModuleTransactionRow(props: { transaction: SafeModuleTransactionWithTra
         <TableCell
           component="th"
           scope="row"
-        >
-          {}
-        </TableCell>
-        <TableCell align="right">{transaction.to}</TableCell>
+        ></TableCell>
+        <TableCell align="right">{transaction.module}</TableCell>
+        <TableCell align="right">{transaction.value}</TableCell>
         <TableCell align="right">{transaction.executionDate}</TableCell>
-        <TableCell align="right">{transaction.blockNumber}</TableCell>
         <TableCell align="right">{transaction.txType}</TableCell>
         <TableCell>
           <IconButton
@@ -204,13 +216,13 @@ function ModuleTransactionRow(props: { transaction: SafeModuleTransactionWithTra
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell>
+        <StyledCollapsibleCell>
           <Collapse
             in={open}
             timeout="auto"
             unmountOnExit
           >
-            <Box>
+            <StyledBox>
               <Typography
                 variant="h6"
                 gutterBottom
@@ -246,9 +258,9 @@ function ModuleTransactionRow(props: { transaction: SafeModuleTransactionWithTra
                   ))}
                 </TableBody> */}
               </Table>
-            </Box>
+            </StyledBox>
           </Collapse>
-        </TableCell>
+        </StyledCollapsibleCell>
       </TableRow>
     </>
   );
@@ -296,27 +308,32 @@ export default function SafeTransactionHistoryPage() {
   }
 
   return (
-    <TableContainer component={Paper}>
-      <Table aria-label="safe transaction history">
-        <TableHead>
-          <TableRow>
-            <TableCell>Nonce</TableCell>
-            <TableCell align="right">Type</TableCell>
-            <TableCell align="right">Amount</TableCell>
-            <TableCell align="right">Time</TableCell>
-            <TableCell align="right">Status</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {safeTransactions?.results.map((transaction, key) => (
-            <TransactionHistoryRow
-              transaction={transaction}
-              key={key}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <Section lightBlue>
+      <TableContainer
+        component={Paper}
+        title="Transaction history"
+      >
+        <Table aria-label="safe transaction history">
+          <TableHead>
+            <TableRow>
+              <TableCell>Nonce</TableCell>
+              <TableCell align="right">Type</TableCell>
+              <TableCell align="right">Amount</TableCell>
+              <TableCell align="right">Time</TableCell>
+              <TableCell align="right">Status</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {safeTransactions?.results.map((transaction, key) => (
+              <TransactionHistoryRow
+                transaction={transaction}
+                key={key}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Section>
   );
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -23,3 +23,14 @@ function convertArrayToCsv<T extends object>(data: T[]) {
   const rows = data.map((obj) => Object.values(obj).join(','));
   return [header, ...rows].join('\n');
 }
+
+export function truncateEthereumAddress(address: string) {
+  // Captures 0x + 4 characters, then the last 4 characters.
+  if (!address) return;
+
+  const truncateRegex = /^(0x[a-zA-Z0-9]{4})[a-zA-Z0-9]+([a-zA-Z0-9]{4})$/;
+
+  const match = address.match(truncateRegex);
+  if (!match) return address;
+  return `${match[1]}…${match[2]}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7291,7 +7291,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viem@^1.0.0, viem@^1.2.12:
+viem@1.2.12, viem@^1.0.0:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/viem/-/viem-1.2.12.tgz#0342f52d05968bd1c2af5db0b9bc569926ae9151"
   integrity sha512-TMhvqT2VaCaJyBfuNDyL1h8xPFyPDHeX6Qab66TjWscnNcTwkW0gojO4Uh+A4RuPzFxIlWSW+b5SjS8SJHlHpg==


### PR DESCRIPTION
closes #112 

### overview
adds a page that shows **all** safe transactions, including the ones that did not run

#### things to improve
- fetching all safe transactions requires adding pagination features to redux, right now it only fetches 20
- pagination in the table 
- module transactions

#### ui
![CleanShot 2023-07-11 at 18 22 00](https://github.com/hoprnet/hopr-admin/assets/22416585/bb6a45b0-472c-4b1f-b683-df7731a58c10)
![CleanShot 2023-07-11 at 18 22 17](https://github.com/hoprnet/hopr-admin/assets/22416585/34990420-57c0-4447-930b-ff9aeeecce92)

