### PR TITLE
Safe transactions increment nonce

### DIFF
--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -210,7 +210,8 @@ const createSafeTransactionThunk = createAsyncThunk(
       const nextSafeNonce = await safeApi.getNextNonce(payload.safeAddress);
       // create safe transaction
       const safeTransaction = await safeSDK.createTransaction({ safeTransactionData: {
-        ...payload.safeTransactionData, nonce: nextSafeNonce, 
+        ...payload.safeTransactionData,
+        nonce: nextSafeNonce,
       } });
       const safeTxHash = await safeSDK.getTransactionHash(safeTransaction);
       const signature = await safeSDK.signTransactionHash(safeTxHash);

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -214,7 +214,7 @@ const createSafeTransactionThunk = createAsyncThunk(
         nonce: nextSafeNonce,
       } });
       const safeTxHash = await safeSDK.getTransactionHash(safeTransaction);
-      const signature = await safeSDK.signTransactionHash(safeTxHash);
+      const signature = await safeSDK.signTypedData(safeTransaction);
       const senderAddress = await payload.signer.getAddress();
       // propose safe transaction
       await safeApi.proposeTransaction({
@@ -257,7 +257,7 @@ const createSafeRejectionTransactionThunk = createAsyncThunk(
       // create safe rejection transaction
       const rejectTransaction = await safeSDK.createRejectionTransaction(payload.nonce);
       const safeTxHash = await safeSDK.getTransactionHash(rejectTransaction);
-      const senderSignature = await safeSDK.signTransactionHash(safeTxHash);
+      const signature = await safeSDK.signTypedData(rejectTransaction);
       const senderAddress = await payload.signer.getAddress();
       // propose safe transaction
       await safeApi.proposeTransaction({
@@ -265,7 +265,7 @@ const createSafeRejectionTransactionThunk = createAsyncThunk(
         safeTransactionData: rejectTransaction.data,
         safeTxHash,
         senderAddress,
-        senderSignature: senderSignature.data,
+        senderSignature: signature.data,
       });
       // re fetch all txs
       dispatch(


### PR DESCRIPTION
closes #121 

### overview
Proposing a new tx will always now have a valid nonce


### example flow
1. safe nonce: 1
2. first proposed tx nonce: 1
3. second proposed tx nonce: 2
4. third proposed tx nonce: 3

### worth mentioning
This allows us to propose different transactions but the order is important. Since the safe nonce is 1 we should only interact with that one. 

The way rejections seem to work makes it impossible to reject a future nonce transaction.

##### weird flow interaction when interacting with future nonce tx
![CleanShot 2023-07-13 at 14 57 48](https://github.com/hoprnet/hopr-admin/assets/22416585/af661de0-186d-4f1d-9a29-b8c991804fce)

we should disable future nonce interaction in #119 