### PR TITLE
Watch low node balance

### DIFF
--- a/src/hooks/useWatcher/balances.ts
+++ b/src/hooks/useWatcher/balances.ts
@@ -41,8 +41,8 @@ export const handleBalanceNotification = ({
   sendNewHoprBalanceNotification: (hoprBalanceDifference: bigint) => void;
   sendNativeBalanceTooLowNotification: (newNativeBalance: bigint) => void;
 }) => {
-  if(BigInt(newNodeBalances.native) < BigInt(minimumNodeBalances.native)) {
-    return sendNativeBalanceTooLowNotification(BigInt(newNodeBalances.native))
+  if (BigInt(newNodeBalances.native) < BigInt(minimumNodeBalances.native)) {
+    return sendNativeBalanceTooLowNotification(BigInt(newNodeBalances.native));
   }
 
   if (!prevNodeBalances) return;

--- a/src/hooks/useWatcher/balances.ts
+++ b/src/hooks/useWatcher/balances.ts
@@ -3,7 +3,7 @@ import { useAppDispatch } from '../../store';
 import { observeData } from './observeData';
 import { nodeActionsAsync } from '../../store/slices/node';
 import { sendNotification } from './notifications';
-import { formatEther, parseEther } from 'viem';
+import { formatEther } from 'viem';
 
 /**
  * Checks if the new balance is greater than the previous balance.
@@ -14,9 +14,6 @@ import { formatEther, parseEther } from 'viem';
  */
 export const balanceHasIncreased = (prevBalance: string, newBalance: string) =>
   BigInt(prevBalance) < BigInt(newBalance);
-
-export const balanceIsLessThanMinimumThreshold = (minimumThreshold: bigint, newBalance: string) =>
-  BigInt(newBalance) < minimumThreshold;
 
 /**
  * Handles balance notifications.

--- a/src/hooks/useWatcher/balances.ts
+++ b/src/hooks/useWatcher/balances.ts
@@ -136,7 +136,7 @@ export const observeNodeBalances = ({
             },
             toastPayload: { message: `Node xDai level is low, node has ${formatEther(
               BigInt(newNativeBalance),
-            )} and should have ${formatEther(BigInt(minimumNodeBalances.native))}}` },
+            )} and should have ${formatEther(BigInt(minimumNodeBalances.native))}` },
             dispatch,
           });
         },

--- a/src/hooks/useWatcher/index.ts
+++ b/src/hooks/useWatcher/index.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { parseEther } from 'viem';
 import { useEthersSigner } from '..';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { appActions } from '../../store/slices/app';
@@ -50,22 +51,26 @@ export const useWatcher = ({ intervalDuration = 10000 }: { intervalDuration?: nu
       });
     }, intervalDuration);
 
-    const watchNodeFundsInterval = setInterval(() => {
+    const watchNodeBalancesInterval = setInterval(() => {
       observeNodeBalances({
         apiEndpoint,
         apiToken,
-        dispatch,
+        minimumNodeBalances: {
+          hopr: '0',
+          native: parseEther('0.003').toString(),
+        },
         previousState: prevNodeBalances,
         updatePreviousData: (newNodeBalances) => {
           dispatch(appActions.setPrevNodeBalances(newNodeBalances));
         },
+        dispatch,
       });
     }, intervalDuration);
 
     return () => {
       clearInterval(watchChannelsInterval);
       clearInterval(watchNodeInfoInterval);
-      clearInterval(watchNodeFundsInterval);
+      clearInterval(watchNodeBalancesInterval);
     };
   }, [apiEndpoint, apiToken, prevNodeBalances, prevNodeInfo, prevChannels]);
 


### PR DESCRIPTION
closes #103 

### overview
Updates the node balances watcher and checks if a node has less than a certain minimum threshold and if so it will send a notification

#### why change the condition on `isDataDifferent` for balance watcher?
Before we would only track when a balance increased but there was actually a hidden bug here, due to the fact that if we withdrew balance and then added balance again it would not send a notification. Meaning that notifications would only send if the balance was higher than the all time high since connecting to the node but not necessarily if we received more tokens. 

Also now that we track if balance decreases it is a simple addition to add a notification if the balance is less than a specified threshold.