### PR TITLE
set allowance for hopr token from safe

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,1 +1,6 @@
 export const environment:('dev' | 'node' | 'web3') = 'dev';
+
+export const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e';
+
+// mHopr
+export const HOPR_TOKEN_SMART_CONTRACT_ADDRESS = '0x66225dE86Cac02b32f34992eb3410F59DE416698';

--- a/config.ts
+++ b/config.ts
@@ -3,4 +3,4 @@ export const environment:('dev' | 'node' | 'web3') = 'dev';
 export const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e';
 
 // mHopr
-export const HOPR_TOKEN_SMART_CONTRACT_ADDRESS = '0x66225dE86Cac02b32f34992eb3410F59DE416698';
+export const mHOPR_TOKEN_SMART_CONTRACT_ADDRESS = '0x66225dE86Cac02b32f34992eb3410F59DE416698';

--- a/src/components/ConnectSafe/index.tsx
+++ b/src/components/ConnectSafe/index.tsx
@@ -116,19 +116,19 @@ export default function ConnectSafe() {
         safeActionsAsync.getSafeInfoThunk({
           signer: signer,
           safeAddress,
-        })
+        }),
       );
       dispatch(
         safeActionsAsync.getAllSafeTransactionsThunk({
           signer,
           safeAddress,
-        })
+        }),
       );
       dispatch(
         safeActionsAsync.getSafeDelegatesThunk({
           signer,
           options: { safeAddress },
-        })
+        }),
       );
       // Additional logic to connect to the safe
     }

--- a/src/components/ConnectWeb3/index.tsx
+++ b/src/components/ConnectWeb3/index.tsx
@@ -72,7 +72,11 @@ type ConnectWeb3Props = {
   onClose?: () => void;
 };
 
-export default function ConnectWeb3({ inTheAppBar, open, onClose }: ConnectWeb3Props) {
+export default function ConnectWeb3({
+  inTheAppBar,
+  open,
+  onClose,
+}: ConnectWeb3Props) {
   const dispatch = useAppDispatch();
   const [chooseWalletModal, set_chooseWalletModal] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null); // State variable to hold the anchor element for the menu

--- a/src/sections/safe.tsx
+++ b/src/sections/safe.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 //Stores
 import { useAppDispatch, useAppSelector } from '../store';
-import { safeActionsAsync, safeActions } from '../store/slices/safe';
+import { safeActionsAsync } from '../store/slices/safe';
 
 // HOPR Components
 import Section from '../future-hopr-lib-components/Section';
@@ -14,11 +14,11 @@ import { Address, encodeFunctionData, formatEther } from 'viem';
 import { erc20ABI, useContractRead } from 'wagmi';
 import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types';
 
-const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e'
+const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e';
 // Maximum possible value for uint256
 const MAX_UINT256 = BigInt(2 ** 256) - BigInt(1);
 // mHopr
-const HOPR_TOKEN_SMART_CONTRACT_ADDRESS = '0x66225dE86Cac02b32f34992eb3410F59DE416698'
+const HOPR_TOKEN_SMART_CONTRACT_ADDRESS = '0x66225dE86Cac02b32f34992eb3410F59DE416698';
 
 function SafeSection() {
   const dispatch = useAppDispatch();
@@ -34,8 +34,8 @@ function SafeSection() {
     abi: erc20ABI,
     functionName: 'allowance',
     args: [safe.selectedSafeAddress as Address, HOPR_CHANNELS_SMART_CONTRACT_ADDRESS],
-  })
-  
+  });
+
   useEffect(() => {
     fetchInitialStateForSigner();
   }, [signer]);
@@ -45,32 +45,34 @@ function SafeSection() {
       dispatch(safeActionsAsync.getSafesByOwnerThunk({ signer }));
     }
   };
-  
+
   const createApproveTransactionData = (spender: Address, value: bigint) => {
     const approveData = encodeFunctionData({
       abi: erc20ABI,
       functionName: 'approve',
       args: [spender, value],
-    })
-    return approveData
-  }
+    });
+    return approveData;
+  };
 
   const proposeApproveTransactionToSafe = async () => {
     if (signer && safe.selectedSafeAddress) {
-      const data = createApproveTransactionData(HOPR_CHANNELS_SMART_CONTRACT_ADDRESS, MAX_UINT256)
+      const data = createApproveTransactionData(HOPR_CHANNELS_SMART_CONTRACT_ADDRESS, MAX_UINT256);
       // creates a safe transaction with data to interact with a smart contract
       const safeTransactionData: SafeTransactionDataPartial = {
         to: HOPR_TOKEN_SMART_CONTRACT_ADDRESS,
         data,
-        value: "0",
-      }
-      await dispatch(safeActionsAsync.createSafeTransactionThunk({
-        signer,
-        safeAddress: safe.selectedSafeAddress,
-        safeTransactionData,
-      })).unwrap()
+        value: '0',
+      };
+      await dispatch(
+        safeActionsAsync.createSafeTransactionThunk({
+          signer,
+          safeAddress: safe.selectedSafeAddress,
+          safeTransactionData,
+        }),
+      ).unwrap();
     }
-  }
+  };
 
   if (!account) {
     return (
@@ -245,7 +247,12 @@ function SafeSection() {
       ))}
       <h2>approve hopr token to hopr channels</h2>
       <span>allowance: {formatEther(BigInt(allowanceData?.toString() ?? '0'))}</span>
-      <button disabled={!safe.selectedSafeAddress || !signer} onClick={proposeApproveTransactionToSafe}>approve</button>
+      <button
+        disabled={!safe.selectedSafeAddress || !signer}
+        onClick={proposeApproveTransactionToSafe}
+      >
+        approve
+      </button>
       <h2>store</h2>
       <pre>{JSON.stringify(safe, null, 4)}</pre>
     </Section>

--- a/src/sections/safe.tsx
+++ b/src/sections/safe.tsx
@@ -13,12 +13,11 @@ import { appActions } from '../store/slices/app';
 import { Address, encodeFunctionData, formatEther } from 'viem';
 import { erc20ABI, useContractRead } from 'wagmi';
 import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types';
+import { HOPR_CHANNELS_SMART_CONTRACT_ADDRESS, HOPR_TOKEN_SMART_CONTRACT_ADDRESS } from '../../config';
 
-const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e';
 // Maximum possible value for uint256
 const MAX_UINT256 = BigInt(2 ** 256) - BigInt(1);
-// mHopr
-const HOPR_TOKEN_SMART_CONTRACT_ADDRESS = '0x66225dE86Cac02b32f34992eb3410F59DE416698';
+
 
 function SafeSection() {
   const dispatch = useAppDispatch();

--- a/src/sections/safe.tsx
+++ b/src/sections/safe.tsx
@@ -14,6 +14,7 @@ import { Address, encodeFunctionData, formatEther } from 'viem';
 import { erc20ABI, useContractRead } from 'wagmi';
 import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types';
 import { HOPR_CHANNELS_SMART_CONTRACT_ADDRESS, mHOPR_TOKEN_SMART_CONTRACT_ADDRESS } from '../../config';
+import { createApproveTransactionData } from '../utils/blockchain';
 
 // Maximum possible value for uint256
 const MAX_UINT256 = BigInt(2 ** 256) - BigInt(1);
@@ -42,15 +43,6 @@ function SafeSection() {
     if (signer) {
       dispatch(safeActionsAsync.getSafesByOwnerThunk({ signer }));
     }
-  };
-
-  const createApproveTransactionData = (spender: Address, value: bigint) => {
-    const approveData = encodeFunctionData({
-      abi: erc20ABI,
-      functionName: 'approve',
-      args: [spender, value],
-    });
-    return approveData;
   };
 
   if (!account) {

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -248,6 +248,49 @@ const createSafeTransactionThunk = createAsyncThunk(
   },
 );
 
+const createSafeContractTransaction = 
+createAsyncThunk(
+  'safe/createContractTransaction',
+  async (
+    payload: {
+      signer: ethers.providers.JsonRpcSigner;
+      safeAddress: string;
+      smartContractAddress: string; 
+      data: string
+    },
+    {
+      rejectWithValue,
+      dispatch,
+    },
+  ) => {
+    try {
+      const {
+        smartContractAddress,
+        data,
+        signer,
+        safeAddress,
+      } = payload 
+
+      const safeTransactionData: SafeTransactionDataPartial = {
+        to: smartContractAddress,
+        data,
+        value: '0',
+      };
+      const safeTxHash = await dispatch(
+        createSafeTransactionThunk({
+          signer,
+          safeAddress: safeAddress,
+          safeTransactionData,
+        }),
+      ).unwrap();
+
+      return safeTxHash
+    } catch (e) {
+      return rejectWithValue(e);
+    }
+  },
+);
+
 const createSafeRejectionTransactionThunk = createAsyncThunk(
   'safe/rejectTransactionProposal',
   async (
@@ -522,4 +565,5 @@ export const actionsAsync = {
   addSafeDelegateThunk,
   removeSafeDelegateThunk,
   getSafeDelegatesThunk,
+  createSafeContractTransaction,
 };

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -248,15 +248,14 @@ const createSafeTransactionThunk = createAsyncThunk(
   },
 );
 
-const createSafeContractTransaction = 
-createAsyncThunk(
+const createSafeContractTransaction = createAsyncThunk(
   'safe/createContractTransaction',
   async (
     payload: {
       signer: ethers.providers.JsonRpcSigner;
       safeAddress: string;
-      smartContractAddress: string; 
-      data: string
+      smartContractAddress: string;
+      data: string;
     },
     {
       rejectWithValue,
@@ -269,7 +268,7 @@ createAsyncThunk(
         data,
         signer,
         safeAddress,
-      } = payload 
+      } = payload;
 
       const safeTransactionData: SafeTransactionDataPartial = {
         to: smartContractAddress,
@@ -284,7 +283,7 @@ createAsyncThunk(
         }),
       ).unwrap();
 
-      return safeTxHash
+      return safeTxHash;
     } catch (e) {
       return rejectWithValue(e);
     }

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -1,5 +1,5 @@
-import { Address, encodeFunctionData } from "viem";
-import { erc20ABI } from "wagmi";
+import { Address, encodeFunctionData } from 'viem';
+import { erc20ABI } from 'wagmi';
 
 export const createApproveTransactionData = (spender: Address, value: bigint) => {
   const approveData = encodeFunctionData({

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -1,0 +1,11 @@
+import { Address, encodeFunctionData } from "viem";
+import { erc20ABI } from "wagmi";
+
+export const createApproveTransactionData = (spender: Address, value: bigint) => {
+  const approveData = encodeFunctionData({
+    abi: erc20ABI,
+    functionName: 'approve',
+    args: [spender, value],
+  });
+  return approveData;
+};


### PR DESCRIPTION
closes #107 

### overview
This pr shows how we can interact with smart contracts from a safe account. It specifically adds the functionality to set allowance of hopr token to hopr channels from the safe account.

### why is `createApproveTransactionData` needed?
Since the allowance actually comes from the holder of tokens which in this case would be the Safe. This means we have to use safe interactions like `proposeTransaction` and `executeTransaction`. To use these interactions we have to pass a specific type `SafeTransactionDataPartial`, which amongst other things contain `{ to: string; value: string; data: string; operation?: OperationType }`. 

So we create the encoded data for the transaction and then pass the data for safe to execute.

[inspiration](https://ethereum.stackexchange.com/questions/116761/how-to-send-erc20-erc721-tokens-using-safe-core-sdk/116793#116793)

### ui
![CleanShot 2023-07-24 at 16 07 10](https://github.com/hoprnet/hopr-admin/assets/22416585/0be87b15-16b5-41e7-ab35-650b7bebe191)

this button can be seen in the /hub/safe subpage so any reviewers can test.