### PR TITLE
Safe account in app bar not updating

### DIFF
--- a/src/components/ConnectSafe/index.tsx
+++ b/src/components/ConnectSafe/index.tsx
@@ -61,7 +61,6 @@ export default function ConnectSafe() {
   const connected = useAppSelector((selector) => selector.web3.status);
   const safes = useAppSelector((selector) => selector.safe.safesByOwner);
   const safeAddress = useAppSelector((selector) => selector.safe.selectedSafeAddress);
-  const [selectedSafeAddress, set_selectedSafeAddress] = useState(safeAddress || '');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null); // State variable to hold the anchor element for the menu
   const prevPendingSafeTransaction = useAppSelector((store) => store.app.previousStates.prevPendingSafeTransaction);
 
@@ -101,7 +100,6 @@ export default function ConnectSafe() {
 
   const useSelectedSafe = (safeAddress: string) => {
     if (signer) {
-      set_selectedSafeAddress(safeAddress);
       dispatch(appActions.resetState());
       observePendingSafeTransactions({
         dispatch,
@@ -116,21 +114,20 @@ export default function ConnectSafe() {
         safeActionsAsync.getSafeInfoThunk({
           signer: signer,
           safeAddress,
-        })
+        }),
       );
       dispatch(
         safeActionsAsync.getAllSafeTransactionsThunk({
           signer,
           safeAddress,
-        })
+        }),
       );
       dispatch(
         safeActionsAsync.getSafeDelegatesThunk({
           signer,
           options: { safeAddress },
-        })
+        }),
       );
-      // Additional logic to connect to the safe
     }
   };
 
@@ -165,7 +162,7 @@ export default function ConnectSafe() {
       {connected.connected ? (
         <>
           <SafeButton>
-            {truncateEthereumAddress(selectedSafeAddress) || '...'} <DropdownArrow src="/assets/dropdown-arrow.svg" />
+            {truncateEthereumAddress(safeAddress || '...') || '...'} <DropdownArrow src="/assets/dropdown-arrow.svg" />
           </SafeButton>
           <Menu
             anchorEl={anchorEl}

--- a/src/components/ConnectWeb3/index.tsx
+++ b/src/components/ConnectWeb3/index.tsx
@@ -72,7 +72,11 @@ type ConnectWeb3Props = {
   onClose?: () => void;
 };
 
-export default function ConnectWeb3({ inTheAppBar, open, onClose }: ConnectWeb3Props) {
+export default function ConnectWeb3({
+  inTheAppBar,
+  open,
+  onClose,
+}: ConnectWeb3Props) {
   const dispatch = useAppDispatch();
   const [chooseWalletModal, set_chooseWalletModal] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null); // State variable to hold the anchor element for the menu


### PR DESCRIPTION
closes #151 

### Overview
Fixes safe account in app bar not updating with redux app. Removed local state that tracked selectedSafeAddress and now it only uses redux state variable.

### how to test?
- connect to a safe
- change mm account
- the expected result is that the safe account in app bar should reset