### PR TITLE
change names in safe redux slice

### DIFF
--- a/src/sections/safePendingTransactions.tsx
+++ b/src/sections/safePendingTransactions.tsx
@@ -137,7 +137,7 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
   const signer = useEthersSigner();
   const dispatch = useAppDispatch();
   const { address } = useAccount();
-  const safeNonce = useAppSelector((state) => state.safe.safeInfo?.nonce);
+  const safeNonce = useAppSelector((state) => state.safe.info?.nonce);
   const [isLoadingApproving, set_isLoadingApproving] = useState<boolean>(false);
   const [isLoadingExecuting, set_isLoadingExecuting] = useState<boolean>(false);
   const [isLoadingRejecting, set_isLoadingRejecting] = useState<boolean>(false);

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -192,8 +192,8 @@ const getSafeInfoThunk = createAsyncThunk(
   ) => {
     try {
       const safeApi = await createSafeApiService(payload.signer);
-      const safeInfo = await safeApi.getSafeInfo(payload.safeAddress);
-      return safeInfo;
+      const info = await safeApi.getSafeInfo(payload.safeAddress);
+      return info;
     } catch (e) {
       return rejectWithValue(e);
     }
@@ -528,7 +528,7 @@ export const createExtraReducers = (builder: ActionReducerMapBuilder<typeof init
   builder.addCase(getSafeInfoThunk.fulfilled, (state, action) => {
     if (action.payload) {
       state.selectedSafeAddress = action.payload.address;
-      state.safeInfo = action.payload;
+      state.info = action.payload;
     }
   });
   builder.addCase(getAllSafeTransactionsThunk.fulfilled, (state, action) => {
@@ -543,7 +543,7 @@ export const createExtraReducers = (builder: ActionReducerMapBuilder<typeof init
   });
   builder.addCase(getSafeDelegatesThunk.fulfilled, (state, action) => {
     if (action.payload) {
-      state.safeDelegates = action.payload;
+      state.delegates = action.payload;
     }
   });
 };

--- a/src/store/slices/safe/index.ts
+++ b/src/store/slices/safe/index.ts
@@ -7,10 +7,11 @@ const safeSlice = createSlice({
   initialState,
   reducers: { resetState: (state) => {
     state.selectedSafeAddress = null;
-    state.safeInfo = null;
+    state.info = null;
     state.allTransactions = null;
     state.pendingTransactions = null;
     state.safesByOwner = [];
+    state.delegates = null;
   } },
   extraReducers: (builder) => createExtraReducers(builder),
 });

--- a/src/store/slices/safe/initialState.ts
+++ b/src/store/slices/safe/initialState.ts
@@ -5,8 +5,8 @@ type InitialState = {
   safesByOwner: string[];
   allTransactions: AllTransactionsListResponse | null;
   pendingTransactions: SafeMultisigTransactionListResponse | null;
-  safeInfo: SafeInfoResponse | null;
-  safeDelegates: SafeDelegateListResponse | null;
+  info: SafeInfoResponse | null;
+  delegates: SafeDelegateListResponse | null;
 };
 
 export const initialState: InitialState = {
@@ -14,6 +14,6 @@ export const initialState: InitialState = {
   safesByOwner: [],
   allTransactions: null,
   pendingTransactions: null,
-  safeInfo: null,
-  safeDelegates: null,
+  info: null,
+  delegates: null,
 };


### PR DESCRIPTION
closes #160 

### overview
the functionality described in the issue already exists and was tested.

#### refactored changes that affect that issue
- rename  `safeDelegates` to `delegates`
- rename  `safeInfo` to `info`