### PR TITLE
Execute when only 1 signature is pending

### DIFF
--- a/src/sections/actions.tsx
+++ b/src/sections/actions.tsx
@@ -161,7 +161,7 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
   const dispatch = useAppDispatch();
   const { address } = useAccount();
   const safeNonce = useAppSelector((state) => state.safe.info?.nonce);
-  const transactionAfterSafeNonce = safeNonce !== transaction.nonce
+  const transactionAfterSafeNonce = safeNonce !== transaction.nonce;
   const [userAction, set_userAction] = useState<'EXECUTE' | 'SIGN' | null>(null);
   const [isLoadingApproving, set_isLoadingApproving] = useState<boolean>(false);
   const [isLoadingExecuting, set_isLoadingExecuting] = useState<boolean>(false);
@@ -169,9 +169,9 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
 
   useEffect(() => {
     if (address) {
-      set_userAction(getUserActionForPendingTransaction(transaction, address))
+      set_userAction(getUserActionForPendingTransaction(transaction, address));
     }
-  }, [address, transaction])
+  }, [address, transaction]);
 
   // TODO: remove this isLoading functions when isLoading is moved to redux
   const executeTx = (transaction: SafeMultisigTransactionResponse) => {
@@ -311,9 +311,9 @@ const PendingTransactionRow = ({ transaction }: { transaction: CustomSafeMultisi
 
   useEffect(() => {
     if (address) {
-      set_userAction(getUserActionForPendingTransaction(transaction, address))
+      set_userAction(getUserActionForPendingTransaction(transaction, address));
     }
-  }, [address, transaction])
+  }, [address, transaction]);
 
   const getTransactionStatus = () => {
     if (userAction === 'EXECUTE') {

--- a/src/sections/actions.tsx
+++ b/src/sections/actions.tsx
@@ -50,6 +50,7 @@ import {
 } from '../store/slices/safe/initialState';
 import { calculateTimeInGMT, formatDateToUserTimezone, formatTimeToUserTimezone } from '../utils/date';
 import { truncateEthereumAddress } from '../utils/blockchain';
+import { getUserActionForPendingTransaction } from '../utils/safeTransactions';
 
 const StyledContainer = styled(Paper)`
   min-width: 800px;
@@ -145,21 +146,6 @@ const StyledHistoryTableRow = styled(TableRow)`
 
 const GNOSIS_BASE_URL = 'https://gnosisscan.io';
 
-/**
- * Checks if transaction is pending approval from connected signer
- * @returns boolean
- */
-const isTransactionPendingApprovalFromSigner = (
-  transaction: SafeMultisigTransactionResponse,
-  address: string | undefined,
-) => {
-  const foundSigner = transaction?.confirmations?.find((confirmation) => confirmation.owner === address);
-  if (foundSigner) {
-    return false;
-  }
-  return true;
-};
-
 const TruncatedEthereumAddressWithTooltip = ({ address }: { address: string }) => {
   return (
     <div>
@@ -175,10 +161,19 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
   const dispatch = useAppDispatch();
   const { address } = useAccount();
   const safeNonce = useAppSelector((state) => state.safe.info?.nonce);
+  const transactionAfterSafeNonce = safeNonce !== transaction.nonce
+  const [userAction, set_userAction] = useState<'EXECUTE' | 'SIGN' | null>(null);
   const [isLoadingApproving, set_isLoadingApproving] = useState<boolean>(false);
   const [isLoadingExecuting, set_isLoadingExecuting] = useState<boolean>(false);
   const [isLoadingRejecting, set_isLoadingRejecting] = useState<boolean>(false);
 
+  useEffect(() => {
+    if (address) {
+      set_userAction(getUserActionForPendingTransaction(transaction, address))
+    }
+  }, [address, transaction])
+
+  // TODO: remove this isLoading functions when isLoading is moved to redux
   const executeTx = (transaction: SafeMultisigTransactionResponse) => {
     if (signer) {
       set_isLoadingExecuting(true);
@@ -239,36 +234,24 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
     }
   };
 
-  const isTransactionApproved = (transaction: SafeMultisigTransactionResponse) => {
-    if (!signer) return false;
-    return (transaction.confirmations?.length ?? 0) >= transaction.confirmationsRequired;
-  };
-
-  const isTransactionExecutable = (transaction: SafeMultisigTransactionResponse) => {
-    if (!signer) return false;
-    if (safeNonce !== transaction.nonce) return false;
-
-    return true;
-  };
-
-  if (isTransactionApproved(transaction)) {
+  if (userAction === 'EXECUTE') {
     return (
       <>
         <StyledButtonGroup>
-          <Tooltip title={!isTransactionExecutable(transaction) && `Earlier actions should be handled first`}>
+          <Tooltip title={transactionAfterSafeNonce && `Earlier actions should be handled first`}>
             <span>
               <StyledBlueButton
-                disabled={!isTransactionExecutable(transaction)}
+                disabled={transactionAfterSafeNonce}
                 onClick={() => rejectTx(transaction)}
               >
                 reject
               </StyledBlueButton>
             </span>
           </Tooltip>
-          <Tooltip title={!isTransactionExecutable(transaction) && `Earlier actions should be handled first`}>
+          <Tooltip title={transactionAfterSafeNonce && `Earlier actions should be handled first`}>
             <span>
               <StyledBlueButton
-                disabled={!isTransactionExecutable(transaction)}
+                disabled={transactionAfterSafeNonce}
                 onClick={() => executeTx(transaction)}
               >
                 execute
@@ -284,11 +267,12 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
     return (
       <>
         <StyledButtonGroup>
-          <Tooltip title={!isTransactionPendingApprovalFromSigner(transaction, address) && 'You have already approved'}>
+          {/* If there is no user action it is because the user has already signed */}
+          <Tooltip title={!userAction && 'You have already approved'}>
             <span>
               <StyledBlueButton
                 onClick={() => approveTx(transaction)}
-                disabled={!isTransactionPendingApprovalFromSigner(transaction, address)}
+                disabled={!userAction}
               >
                 approve/sign
               </StyledBlueButton>
@@ -307,6 +291,7 @@ const PendingTransactionRow = ({ transaction }: { transaction: CustomSafeMultisi
   const signer = useEthersSigner();
   const dispatch = useAppDispatch();
   const [open, set_open] = useState(false);
+  const [userAction, set_userAction] = useState<'EXECUTE' | 'SIGN' | null>(null);
   // value can represent token value or json params of data
   const [value, set_value] = useState<string>();
   const [currency, set_currency] = useState<string>();
@@ -320,16 +305,22 @@ const PendingTransactionRow = ({ transaction }: { transaction: CustomSafeMultisi
       getCurrencyFromTransaction(transaction, signer).then((currency) => set_currency(currency));
       set_dateInGMT(calculateTimeInGMT(transaction.submissionDate));
       set_dateInUserTimezone(formatDateToUserTimezone(transaction.submissionDate));
-      set_transactionStatus(getTransactionStatus(transaction));
+      set_transactionStatus(getTransactionStatus());
     }
   }, [signer, transaction]);
 
-  const getTransactionStatus = (transaction: SafeMultisigTransactionResponse) => {
-    if (transaction.confirmations?.length === transaction.confirmationsRequired) {
+  useEffect(() => {
+    if (address) {
+      set_userAction(getUserActionForPendingTransaction(transaction, address))
+    }
+  }, [address, transaction])
+
+  const getTransactionStatus = () => {
+    if (userAction === 'EXECUTE') {
       return 'Awaiting execution';
     }
 
-    if (isTransactionPendingApprovalFromSigner(transaction, address)) {
+    if (userAction === 'SIGN') {
       return 'Needs your confirmation ';
     }
 

--- a/src/sections/safe.tsx
+++ b/src/sections/safe.tsx
@@ -5,15 +5,14 @@ import { useAppDispatch, useAppSelector } from '../store';
 import { safeActionsAsync } from '../store/slices/safe';
 
 // HOPR Components
+import { utils } from 'ethers';
+import { Address, formatEther } from 'viem';
+import { erc20ABI, useContractRead } from 'wagmi';
+import { HOPR_CHANNELS_SMART_CONTRACT_ADDRESS, mHOPR_TOKEN_SMART_CONTRACT_ADDRESS } from '../../config';
 import Section from '../future-hopr-lib-components/Section';
 import { useEthersSigner } from '../hooks';
-import { utils } from 'ethers';
 import { observePendingSafeTransactions } from '../hooks/useWatcher/safeTransactions';
 import { appActions } from '../store/slices/app';
-import { Address, encodeFunctionData, formatEther } from 'viem';
-import { erc20ABI, useContractRead } from 'wagmi';
-import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types';
-import { HOPR_CHANNELS_SMART_CONTRACT_ADDRESS, mHOPR_TOKEN_SMART_CONTRACT_ADDRESS } from '../../config';
 import { createApproveTransactionData } from '../utils/blockchain';
 
 // Maximum possible value for uint256

--- a/src/utils/safeTransactions.ts
+++ b/src/utils/safeTransactions.ts
@@ -1,4 +1,4 @@
-import { AllTransactionsListResponse, EthereumTxWithTransfersResponse, SafeModuleTransactionWithTransfersResponse, SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit';
+import { AllTransactionsListResponse, EthereumTxWithTransfersResponse, SafeModuleTransactionWithTransfersResponse, SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit'
 import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import { Address, decodeFunctionData, formatEther, formatUnits } from 'viem';
 import { erc20ABI, erc4626ABI, erc721ABI } from 'wagmi';
@@ -46,33 +46,37 @@ export const getSourceOfPendingTransaction = (transaction: SafeMultisigTransacti
   return truncateEthereumAddress(transaction.confirmations.at(0)?.owner ?? '');
 };
 
-export const getUserActionForPendingTransaction = (transaction: SafeMultisigTransactionResponse, ownerAddress: string): "EXECUTE" | "SIGN" | null => {
-  if (!ownerAddress) return null
+export const getUserActionForPendingTransaction = (
+  transaction: SafeMultisigTransactionResponse,
+  ownerAddress: string,
+): 'EXECUTE' | 'SIGN' | null => {
+  if (!ownerAddress) return null;
 
   const transactionHasEnoughSignatures = (transaction.confirmations?.length ?? 0) >= transaction.confirmationsRequired;
 
   if (transactionHasEnoughSignatures) {
-    return 'EXECUTE'
+    return 'EXECUTE';
   }
 
-  const ownerHasSignedTransaction = transaction?.confirmations?.find((confirmation) => confirmation.owner === ownerAddress);
+  const ownerHasSignedTransaction = transaction?.confirmations?.find(
+    (confirmation) => confirmation.owner === ownerAddress,
+  );
 
   if (ownerHasSignedTransaction) {
     // transaction does not have enough signatures and owner has already signed
     // can only wait for more signatures
-    return null
+    return null;
   }
 
-  const oneSignaturePending = transaction.confirmationsRequired - (transaction.confirmations?.length ?? 0)
+  const oneSignaturePending = transaction.confirmationsRequired - (transaction.confirmations?.length ?? 0);
 
   if (oneSignaturePending) {
-    return 'EXECUTE'
+    return 'EXECUTE';
   }
 
   // more than 1 signature is pending and owner has not signed
-  return 'SIGN'
-}
-
+  return 'SIGN';
+};
 
 /**
  * Ethereum transactions

--- a/src/utils/safeTransactions.ts
+++ b/src/utils/safeTransactions.ts
@@ -1,10 +1,15 @@
-import { AllTransactionsListResponse, EthereumTxWithTransfersResponse, SafeModuleTransactionWithTransfersResponse, SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit'
+import { AllTransactionsListResponse, EthereumTxWithTransfersResponse, SafeModuleTransactionWithTransfersResponse, SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit';
 import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import { Address, decodeFunctionData, formatEther, formatUnits } from 'viem';
 import { erc20ABI, erc4626ABI, erc721ABI } from 'wagmi';
 import safeABI from '../abi/safeAbi.json';
 import { truncateEthereumAddress } from './blockchain';
 
+/**
+ * Pending transactions
+ */
+
+/** Human readable explanation of what the transaction is going to do */
 export const getRequestOfPendingTransaction = (transaction: SafeMultisigTransactionResponse) => {
   if (transaction.data) {
     try {
@@ -41,6 +46,38 @@ export const getSourceOfPendingTransaction = (transaction: SafeMultisigTransacti
   return truncateEthereumAddress(transaction.confirmations.at(0)?.owner ?? '');
 };
 
+export const getUserActionForPendingTransaction = (transaction: SafeMultisigTransactionResponse, ownerAddress: string): "EXECUTE" | "SIGN" | null => {
+  if (!ownerAddress) return null
+
+  const transactionHasEnoughSignatures = (transaction.confirmations?.length ?? 0) >= transaction.confirmationsRequired;
+
+  if (transactionHasEnoughSignatures) {
+    return 'EXECUTE'
+  }
+
+  const ownerHasSignedTransaction = transaction?.confirmations?.find((confirmation) => confirmation.owner === ownerAddress);
+
+  if (ownerHasSignedTransaction) {
+    // transaction does not have enough signatures and owner has already signed
+    // can only wait for more signatures
+    return null
+  }
+
+  const oneSignaturePending = transaction.confirmationsRequired - (transaction.confirmations?.length ?? 0)
+
+  if (oneSignaturePending) {
+    return 'EXECUTE'
+  }
+
+  // more than 1 signature is pending and owner has not signed
+  return 'SIGN'
+}
+
+
+/**
+ * Ethereum transactions
+ */
+
 const getValueFromHistoryEthereumTransaction = (transaction: EthereumTxWithTransfersResponse) => {
   if (!transaction.transfers.at(0)?.tokenAddress) {
     // native transfer
@@ -66,6 +103,10 @@ const getSourceFromHistoryEthereumTransaction = (transaction: EthereumTxWithTran
   return source;
 };
 
+/**
+ * Module transactions
+ */
+
 const getValueFromHistoryModuleTransaction = (transaction: SafeModuleTransactionWithTransfersResponse) => {
   const units = transaction.transfers.at(0)?.tokenInfo.decimals ?? 18;
   const value = formatUnits(BigInt(transaction.transfers.at(0)?.value ?? 0), units);
@@ -76,6 +117,10 @@ const getCurrencyFromHistoryModuleTransaction = (transaction: SafeModuleTransact
   const currency = transaction.transfers.at(0)?.tokenInfo.symbol;
   return currency;
 };
+
+/**
+ * Multisig transactions
+ */
 
 const getValueFromHistoryMultisigTransaction = (transaction: SafeMultisigTransactionWithTransfersResponse) => {
   const value = formatEther(BigInt(transaction.transfers.at(0)?.value ?? 0));
@@ -117,6 +162,10 @@ const getRequestFromHistoryMultisigTransaction = (transaction: SafeMultisigTrans
     return 'Rejection';
   }
 };
+
+/**
+ * History transactions (MULTISIG/MODULE/ETHEREUM)
+ */
 
 export const getSourceFromHistoryTransaction = (transaction: AllTransactionsListResponse['results']['0']) => {
   if (transaction.txType === 'ETHEREUM_TRANSACTION') {


### PR DESCRIPTION
### overview
Remove the obligation to sign and execute when there is only 1 signature left. Instead allow the user to execute straight away because execution transactions already append a signature.

#### how can i know if i can execute my transaction?
created `getUserActionForPendingTransaction` which can return 'EXECUTE' | 'SIGN' | null.

- Whenever this transaction returns 'EXECUTE' then the transaction is ready to run either because it has reached the minimum of transactions or because there is only 1 signature missing.
- It will return SIGN when more than 1 signature is missing and the connected account has not signed yet
- null basically means the user can not do anything because the user has already signed and more than 1 signature is missing.

#### Proof of concept
Actions subpage has been updated to use the new functionality.
