### PR TITLE
Update safe actions buttons and sections to use execute

### DIFF
--- a/src/sections/actions.tsx
+++ b/src/sections/actions.tsx
@@ -178,7 +178,7 @@ const ActionButtons = ({ transaction }: { transaction: SafeMultisigTransactionRe
     if (signer) {
       set_isLoadingExecuting(true);
       dispatch(
-        safeActionsAsync.executeTransactionThunk({
+        safeActionsAsync.executePendingTransactionThunk({
           safeAddress: transaction.safe,
           signer,
           safeTransaction: transaction,

--- a/src/sections/safe.tsx
+++ b/src/sections/safe.tsx
@@ -184,7 +184,7 @@ function SafeSection() {
                 onClick={() => {
                   if (signer) {
                     dispatch(
-                      safeActionsAsync.executeTransactionThunk({
+                      safeActionsAsync.executePendingTransactionThunk({
                         signer,
                         safeAddress: transaction.safe,
                         safeTransaction: transaction,

--- a/src/sections/safeWithdraw.tsx
+++ b/src/sections/safeWithdraw.tsx
@@ -203,15 +203,15 @@ function SafeWithdraw() {
 
       if (safeTx) {
         await dispatch(
-          safeActionsAsync.executeTransactionThunk({
+          safeActionsAsync.executePendingTransactionThunk({
             safeAddress: selectedSafeAddress,
             signer,
             safeTransaction: safeTx,
           }),
         )
           .unwrap()
-          .then((res) => {
-            console.log('executeTransactionThunk success', res);
+          .then((res: unknown) => {
+            console.log('executePendingTransactionThunk success', res);
           })
           .finally(() => {
             set_isExecuting(false);

--- a/src/sections/safeWithdraw.tsx
+++ b/src/sections/safeWithdraw.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { useSearchParams } from 'react-router-dom';
-import { SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit';
 import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import { parseUnits } from 'viem';
 import { useAppDispatch, useAppSelector } from '../store';
@@ -12,7 +11,6 @@ import { xHOPR_TOKEN_SMART_CONTRACT_ADDRESS, wxHOPR_TOKEN_SMART_CONTRACT_ADDRESS
 
 // components
 import Button from '../future-hopr-lib-components/Button';
-import GrayButton from '../future-hopr-lib-components/Button/gray';
 import Section from '../future-hopr-lib-components/Section';
 import Card from '../components/Card';
 
@@ -21,6 +19,8 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Select from '../future-hopr-lib-components/Select';
 import { SelectChangeEvent } from '@mui/material/Select';
+import { useAccount } from 'wagmi';
+import { getUserActionForPendingTransaction, getUserCanSkipProposal } from '../utils/safeTransactions';
 
 const StyledForm = styled.div`
   width: 100%;
@@ -88,11 +88,6 @@ const StyledPendingSafeTransactions = styled.div`
   flex-direction: column;
 `;
 
-const StyledApproveButton = styled(Button)`
-  align-self: flex-start;
-  text-transform: uppercase;
-`;
-
 const InputWithLabel = styled.div`
   display: flex;
   flex-direction: row;
@@ -116,16 +111,23 @@ const supportedTokens = [
     smartContract: xHOPR_TOKEN_SMART_CONTRACT_ADDRESS,
   },
 ];
+
 const supportedTokensValues = supportedTokens.map((elem) => elem.value);
 type SupportedTokens = (typeof supportedTokensValues)[number];
-const isSupportedToken = (x: any): x is SupportedTokens => supportedTokensValues.includes(x);
+const isSupportedToken = (x: string | null): x is SupportedTokens => (x ? supportedTokensValues.includes(x) : false);
 
 function SafeWithdraw() {
   const dispatch = useAppDispatch();
+  // hooks
   const [searchParams, setSearchParams] = useSearchParams();
   const tokenParam = searchParams.get('token');
   const pendingTransactions = useAppSelector((state) => state.safe.pendingTransactions);
   const selectedSafeAddress = useAppSelector((state) => state.safe.selectedSafeAddress);
+  const safeInfo = useAppSelector((state) => state.safe.info);
+  const { address } = useAccount();
+  // local state
+  const [userCanSkipProposal, set_userCanSkipProposal] = useState(false);
+  const [userAction, set_userAction] = useState<'EXECUTE' | 'SIGN' | null>(null);
   const [ethValue, set_ethValue] = useState<string>('');
   const [receiver, set_receiver] = useState<string>('');
   const [token, set_token] = useState<SupportedTokens>(isSupportedToken(tokenParam) ? tokenParam : 'xdai');
@@ -139,11 +141,16 @@ function SafeWithdraw() {
   useEffect(() => {
     if (proposedTxHash) {
       const foundProposedTx = pendingTransactions?.results.find((tx) => tx.safeTxHash === proposedTxHash);
-      if (foundProposedTx) {
+      if (foundProposedTx && address) {
         set_proposedTx(foundProposedTx);
+        set_userAction(getUserActionForPendingTransaction(foundProposedTx, address));
       }
     }
-  }, [pendingTransactions, proposedTxHash]);
+  }, [pendingTransactions, proposedTxHash, address]);
+
+  useEffect(() => {
+    set_userCanSkipProposal(getUserCanSkipProposal(safeInfo));
+  }, [safeInfo]);
 
   const proposeTx = () => {
     if (signer && Number(ethValue) && selectedSafeAddress) {
@@ -222,11 +229,49 @@ function SafeWithdraw() {
     }
   };
 
-  const transactionHasEnoughApprovals = () => {
-    if (!proposedTx) return false;
-    if (!proposedTx.confirmations) return false;
-
-    return proposedTx.confirmations.length >= proposedTx.confirmationsRequired;
+  const createAndExecuteTx = () => {
+    if (signer && Number(ethValue) && selectedSafeAddress) {
+      set_isExecuting(true);
+      if (token === 'xdai') {
+        const parsedValue = parseUnits(ethValue as `${number}`, 18).toString();
+        dispatch(
+          safeActionsAsync.createAndExecuteTransactionThunk({
+            signer,
+            safeAddress: selectedSafeAddress,
+            safeTransactionData: {
+              to: receiver,
+              value: parsedValue as string,
+              data: '0x',
+            },
+          }),
+        )
+          .unwrap()
+          .then((safeTxHash) => {
+            set_proposedTxHash(safeTxHash);
+          })
+          .finally(() => {
+            set_isExecuting(false);
+          });
+      } else {
+        const smartContractAddress = supportedTokens.filter((elem) => elem.value === token)[0].smartContract as string;
+        const parsedValue = parseUnits(ethValue as `${number}`, 18).toString() as unknown;
+        dispatch(
+          safeActionsAsync.createAndExecuteContractTransactionThunk({
+            data: createSendTokensTransactionData(receiver as `0x${string}`, parsedValue as bigint),
+            signer,
+            safeAddress: selectedSafeAddress,
+            smartContractAddress,
+          }),
+        )
+          .unwrap()
+          .then((safeTxHash) => {
+            set_proposedTxHash(safeTxHash);
+          })
+          .finally(() => {
+            set_isExecuting(false);
+          });
+      }
+    }
   };
 
   const getErrorsForSafeTx = ({ customValidator }: { customValidator?: () => { errors: string[] } }) => {
@@ -244,6 +289,12 @@ function SafeWithdraw() {
       errors.push('receiver is required');
     }
 
+    // only require xDai value if there
+    // is no proposed tx
+    if (!ethValue && !proposedTx) {
+      errors.push('xDai value is required');
+    }
+
     if (customValidator) {
       const customErrors = customValidator();
       errors.push(...customErrors.errors);
@@ -259,7 +310,8 @@ function SafeWithdraw() {
 
   const getErrorsForExecuteButton = () =>
     getErrorsForSafeTx({ customValidator: () => {
-      return transactionHasEnoughApprovals() ? { errors: [] } : { errors: ['transaction requires more approvals'] };
+      // no user action means the user can not do anything
+      return !userAction ? { errors: [] } : { errors: ['transaction requires more approvals'] };
     } });
 
   const handleChangeToken = (event: SelectChangeEvent<unknown>) => {
@@ -270,17 +322,18 @@ function SafeWithdraw() {
     }
   };
 
-  const handleApprove = () => {
-    if (signer && proposedTx) {
-      dispatch(
-        safeActionsAsync.confirmTransactionThunk({
-          signer,
-          safeAddress: proposedTx.safe,
-          safeTransactionHash: proposedTx.safeTxHash,
-        }),
-      );
-    }
-  };
+  // multiple owners is out of scope for initial version
+  // const handleApprove = () => {
+  //   if (signer && proposedTx) {
+  //     dispatch(
+  //       safeActionsAsync.confirmTransactionThunk({
+  //         signer,
+  //         safeAddress: proposedTx.safe,
+  //         safeTransactionHash: proposedTx.safeTxHash,
+  //       }),
+  //     );
+  //   }
+  // };
 
   return (
     <Section
@@ -346,7 +399,7 @@ function SafeWithdraw() {
           {!!proposedTx && (
             <StyledPendingSafeTransactions>
               <StyledDescription>
-                {transactionHasEnoughApprovals()
+                {userAction === 'EXECUTE'
                   ? 'transaction has been approved by required owners, now can be executed'
                   : `transaction is pending ${
                     (proposedTx?.confirmationsRequired ?? 0) - (proposedTx?.confirmations?.length ?? 0)
@@ -359,7 +412,7 @@ function SafeWithdraw() {
             </StyledPendingSafeTransactions>
           )}
           <StyledButtonGroup>
-            {!proposedTx ? (
+            {!userCanSkipProposal ? (
               <Tooltip title={isSigning ? 'Signing transation' : getErrorsForApproveButton().at(0)}>
                 <span>
                   <StyledBlueButton
@@ -375,7 +428,8 @@ function SafeWithdraw() {
                 <span>
                   <StyledBlueButton
                     disabled={!!getErrorsForExecuteButton().length || isExecuting}
-                    onClick={executeTx}
+                    // no need to propose tx with only 1 threshold
+                    onClick={proposedTx ? executeTx : createAndExecuteTx}
                   >
                     Execute
                   </StyledBlueButton>

--- a/src/steps/xdaiToNode.tsx
+++ b/src/steps/xdaiToNode.tsx
@@ -9,7 +9,6 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 
 // components
-import { SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit';
 import { useEffect, useState } from 'react';
 import { parseUnits } from 'viem';
 import Button from '../future-hopr-lib-components/Button';
@@ -123,7 +122,7 @@ function XdaiToNode() {
     if (signer && Number(xdaiValue) && selectedSafeAddress && nodeNativeAddress) {
       set_isLoading(true);
       dispatch(
-        safeActionsAsync.createSafeTransactionThunk({
+        safeActionsAsync.createAndExecuteTransactionThunk({
           signer,
           safeAddress: selectedSafeAddress,
           safeTransactionData: {
@@ -155,7 +154,7 @@ function XdaiToNode() {
 
       if (safeTx) {
         dispatch(
-          safeActionsAsync.executeTransactionThunk({
+          safeActionsAsync.executePendingTransactionThunk({
             safeAddress: selectedSafeAddress,
             signer,
             safeTransaction: safeTx,

--- a/src/steps/xdaiToNode.tsx
+++ b/src/steps/xdaiToNode.tsx
@@ -191,7 +191,8 @@ function XdaiToNode() {
           data: '0x',
         },
       }),
-    ) .unwrap()
+    )
+      .unwrap()
       .then(() => {
         set_isExecutionLoading(false);
       })

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -493,14 +493,8 @@ const createAndExecuteTransactionThunk = createAsyncThunk(
   ) => {
     try {
       const safeSDK = await createSafeSDK(payload.signer, payload.safeAddress);
-      const safeApi = await createSafeApiService(payload.signer);
-      // gets next nonce considering pending txs
-      const nextSafeNonce = await safeApi.getNextNonce(payload.safeAddress);
       // create safe transaction
-      const safeTransaction = await safeSDK.createTransaction({ safeTransactionData: {
-        ...payload.safeTransactionData,
-        nonce: nextSafeNonce,
-      } });
+      const safeTransaction = await safeSDK.createTransaction({ safeTransactionData: payload.safeTransactionData });
       const safeTxHash = await safeSDK.getTransactionHash(safeTransaction);
       const isValidTx = await safeSDK.isValidTransaction(safeTransaction);
       if (!isValidTx) {

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -522,6 +522,49 @@ const createAndExecuteTransactionThunk = createAsyncThunk(
   },
 );
 
+const createAndExecuteContractTransactionThunk = createAsyncThunk(
+  'safe/createAndExecuteContractTransaction',
+  async (
+    payload: {
+      signer: ethers.providers.JsonRpcSigner;
+      safeAddress: string;
+      smartContractAddress: string;
+      data: string;
+    },
+    {
+      rejectWithValue,
+      dispatch,
+    },
+  ) => {
+    try {
+      const {
+        smartContractAddress,
+        data,
+        signer,
+        safeAddress,
+      } = payload;
+
+      const safeTransactionData: SafeTransactionDataPartial = {
+        to: smartContractAddress,
+        data,
+        value: '0',
+      };
+
+      const safeTxHash = await dispatch(
+        createAndExecuteTransactionThunk({
+          signer,
+          safeAddress: safeAddress,
+          safeTransactionData,
+        }),
+      ).unwrap();
+
+      return safeTxHash;
+    } catch (e) {
+      return rejectWithValue(e);
+    }
+  },
+);
+
 const getAllSafeTransactionsThunk = createAsyncThunk(
   'safe/getAllSafeTransactions',
   async (
@@ -747,4 +790,5 @@ export const actionsAsync = {
   updateSafeThresholdThunk,
   createSafeContractTransaction,
   createAndExecuteTransactionThunk,
+  createAndExecuteContractTransactionThunk,
 };

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -444,7 +444,7 @@ const confirmTransactionThunk = createAsyncThunk(
   },
 );
 
-const executeTransactionThunk = createAsyncThunk(
+const executePendingTransactionThunk = createAsyncThunk(
   'safe/executeTransactionProposal',
   async (
     payload: {
@@ -468,6 +468,54 @@ const executeTransactionThunk = createAsyncThunk(
         }),
       );
       return true;
+    } catch (e) {
+      return rejectWithValue(e);
+    }
+  },
+);
+
+/**
+ * Creates a safe transaction and executes, skips proposing.
+ * This only works if the safe has threshold of 1
+ */
+const createAndExecuteTransactionThunk = createAsyncThunk(
+  'safe/createAndExecuteTransaction',
+  async (
+    payload: {
+      signer: ethers.providers.JsonRpcSigner;
+      safeAddress: string;
+      safeTransactionData: SafeTransactionDataPartial;
+    },
+    {
+      rejectWithValue,
+      dispatch,
+    },
+  ) => {
+    try {
+      const safeSDK = await createSafeSDK(payload.signer, payload.safeAddress);
+      const safeApi = await createSafeApiService(payload.signer);
+      // gets next nonce considering pending txs
+      const nextSafeNonce = await safeApi.getNextNonce(payload.safeAddress);
+      // create safe transaction
+      const safeTransaction = await safeSDK.createTransaction({ safeTransactionData: {
+        ...payload.safeTransactionData,
+        nonce: nextSafeNonce,
+      } });
+      const safeTxHash = await safeSDK.getTransactionHash(safeTransaction);
+      const isValidTx = await safeSDK.isValidTransaction(safeTransaction)
+      if (!isValidTx) {
+        throw Error('Transaction is not valid')
+      }
+      // execute safe transaction
+      await safeSDK.executeTransaction(safeTransaction);
+      // re fetch all txs
+      dispatch(
+        getAllSafeTransactionsThunk({
+          safeAddress: payload.safeAddress,
+          signer: payload.signer,
+        }),
+      );
+      return safeTxHash;
     } catch (e) {
       return rejectWithValue(e);
     }
@@ -689,7 +737,7 @@ export const actionsAsync = {
   createSafeRejectionTransactionThunk,
   createSafeTransactionThunk,
   getSafeInfoThunk,
-  executeTransactionThunk,
+  executePendingTransactionThunk,
   getPendingSafeTransactionsThunk,
   addSafeDelegateThunk,
   removeSafeDelegateThunk,
@@ -698,4 +746,5 @@ export const actionsAsync = {
   getTokenList,
   updateSafeThresholdThunk,
   createSafeContractTransaction,
+  createAndExecuteTransactionThunk,
 };

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -502,9 +502,9 @@ const createAndExecuteTransactionThunk = createAsyncThunk(
         nonce: nextSafeNonce,
       } });
       const safeTxHash = await safeSDK.getTransactionHash(safeTransaction);
-      const isValidTx = await safeSDK.isValidTransaction(safeTransaction)
+      const isValidTx = await safeSDK.isValidTransaction(safeTransaction);
       if (!isValidTx) {
-        throw Error('Transaction is not valid')
+        throw Error('Transaction is not valid');
       }
       // execute safe transaction
       await safeSDK.executeTransaction(safeTransaction);

--- a/src/utils/safeTransactions.ts
+++ b/src/utils/safeTransactions.ts
@@ -1,4 +1,10 @@
-import { AllTransactionsListResponse, EthereumTxWithTransfersResponse, SafeModuleTransactionWithTransfersResponse, SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit'
+import {
+  AllTransactionsListResponse,
+  EthereumTxWithTransfersResponse,
+  SafeInfoResponse,
+  SafeModuleTransactionWithTransfersResponse,
+  SafeMultisigTransactionWithTransfersResponse
+} from '@safe-global/api-kit'
 import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import { Address, decodeFunctionData, formatEther, formatUnits } from 'viem';
 import { erc20ABI, erc4626ABI, erc721ABI } from 'wagmi';
@@ -77,6 +83,18 @@ export const getUserActionForPendingTransaction = (
   // more than 1 signature is pending and owner has not signed
   return 'SIGN';
 };
+
+export const getUserCanSkipProposal = (safeInfo: SafeInfoResponse | null) => {
+  if (!safeInfo) {
+    return false
+  }
+  
+  if (safeInfo.threshold === 1) {
+    return true
+  } 
+
+  return false
+}
 
 /**
  * Ethereum transactions

--- a/src/utils/safeTransactions.ts
+++ b/src/utils/safeTransactions.ts
@@ -4,7 +4,7 @@ import {
   SafeInfoResponse,
   SafeModuleTransactionWithTransfersResponse,
   SafeMultisigTransactionWithTransfersResponse
-} from '@safe-global/api-kit'
+} from '@safe-global/api-kit';
 import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
 import { Address, decodeFunctionData, formatEther, formatUnits } from 'viem';
 import { erc20ABI, erc4626ABI, erc721ABI } from 'wagmi';
@@ -86,15 +86,15 @@ export const getUserActionForPendingTransaction = (
 
 export const getUserCanSkipProposal = (safeInfo: SafeInfoResponse | null) => {
   if (!safeInfo) {
-    return false
+    return false;
   }
-  
-  if (safeInfo.threshold === 1) {
-    return true
-  } 
 
-  return false
-}
+  if (safeInfo.threshold === 1) {
+    return true;
+  }
+
+  return false;
+};
 
 /**
  * Ethereum transactions


### PR DESCRIPTION
continuation of #177

### overview
In the the pr #177 we managed to check that we can execute proposed transactions when only 1 signature is pending. In this pr there is a new function `getUserCanSkipProposal ` which allows us to know if the safe has 1 threshold and transactions don't have to be proposed but can be directly executed by an owner.

#### new safe redux functions and renaming old ones
- created createAndExecuteTransactionThunk
- created createAndExecuteContractTransactionThunk
- rename executeTransactionThunk to executePendingTransactionThunk because it required a transaction to exist.

#### out of scope
creating and executing transactions can invalidate a pending transaction. It will run straight away and not in a future nonce, so it can indirectly reject a pending transaction.