### PR TITLE
Bugfix constant minute in actions subpage

### DIFF
--- a/src/sections/actions.tsx
+++ b/src/sections/actions.tsx
@@ -526,16 +526,19 @@ function EthereumTransactionRow(props: { transaction: CustomEthereumTxWithTransf
           </IconButton>
           {date}
         </TableCell>
-        <TableCell align="right">{time}</TableCell>
+        <TableCell>{time}</TableCell>
         <TableCell align="right">
           <TruncatedEthereumAddressWithTooltip address={transaction.source} />
         </TableCell>
         <TableCell align="right">{transaction.request}</TableCell>
-        <TableCell align="right">{`${
-          transaction.value && transaction.value.length > 18
-            ? transaction.value.slice(0, 18).concat('...')
-            : transaction.value
-        } ${transaction.currency}`}</TableCell>
+        <TableCell
+          align="right"
+          colSpan={2}
+        >{`${
+            transaction.value && transaction.value.length > 18
+              ? transaction.value.slice(0, 18).concat('...')
+              : transaction.value
+          } ${transaction.currency}`}</TableCell>
       </StyledHistoryTableRow>
       <StyledHistoryTableRow>
         <StyledCollapsibleCell colSpan={6}>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -16,12 +16,12 @@ export const formatTimeToUserTimezone = (date: string) => {
   dayjs.extend(timezone);
   // guess user timezone;
   const userTimezone = dayjs.tz.guess();
-  const formattedDate = dayjs(date).tz(userTimezone).format('HH:MM');
+  const formattedDate = dayjs(date).tz(userTimezone).format('HH:mm');
   return formattedDate;
 };
 
 export const calculateTimeInGMT = (date: string) => {
   dayjs.extend(utc);
-  const timeInGMT = `${dayjs(date).utc().format('YYYY-MM-DD HH:MM')} GMT ${dayjs(date).utc().format('Z')}`;
+  const timeInGMT = `${dayjs(date).utc().format('YYYY-MM-DD HH:mm')} GMT ${dayjs(date).utc().format('Z')}`;
   return timeInGMT;
 };


### PR DESCRIPTION
closes #185 

### overview
dayjs parsing change, before instead of minute it would show month. This pr also includes a small aligning changes for ethereum history transactions


### before style changes
![CleanShot 2023-08-08 at 15 24 35](https://github.com/hoprnet/hopr-admin/assets/22416585/1edd9872-cb4e-4d08-b69d-2c643fc5414a)

### after style changes
![CleanShot 2023-08-08 at 15 23 48](https://github.com/hoprnet/hopr-admin/assets/22416585/f6dbe3cd-1b39-46b1-9755-2d02fbaf44d7)

slight alignment on time and value

