### PR TITLE
wagmi use wallet provider

### DIFF
--- a/src/hooks/useWatcher/safeTransactions.ts
+++ b/src/hooks/useWatcher/safeTransactions.ts
@@ -1,6 +1,6 @@
 import { SafeMultisigTransactionListResponse } from '@safe-global/api-kit';
 import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types';
-import ethers from 'ethers';
+import { ethers } from 'ethers';
 import { safeActionsAsync } from '../../store/slices/safe';
 import { useAppDispatch } from '../../store';
 import { sendNotification } from './notifications';

--- a/src/providers/wagmi/index.tsx
+++ b/src/providers/wagmi/index.tsx
@@ -3,27 +3,54 @@ import Updater from './updater';
 
 // wagmi
 import { gnosis } from '@wagmi/core/chains';
+import { jsonRpcProvider } from '@wagmi/core/providers/jsonRpc';
 import { publicProvider } from 'wagmi/providers/public';
-import { WagmiConfig, createConfig, configureChains } from 'wagmi';
-import { createPublicClient, http } from 'viem';
+import { ethers } from 'ethers';
+import { Chain, WagmiConfig, configureChains, createConfig } from 'wagmi';
 
 //wagmi connectors
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
+import { createWalletClient, custom, publicActions } from 'viem';
+
+type WindowWithWallet = { ethereum: ethers.providers.ExternalProvider };
+
+const walletProvider = (chain: Chain) => {
+  if (typeof window !== 'undefined' && typeof (window as unknown as WindowWithWallet).ethereum !== 'undefined') {
+    const provider = new ethers.providers.Web3Provider((window as unknown as WindowWithWallet).ethereum, {
+      chainId: chain.id,
+      name: chain.network,
+      ensAddress: chain.contracts?.ensRegistry?.address,
+    }); 
+
+    return provider
+  }
+
+  // no web3 found in window
+  return null;
+};
+
+const client = createWalletClient({
+  chain: gnosis,
+  transport: custom((window as unknown as WindowWithWallet).ethereum as any),
+}).extend(publicActions)
 
 const {
   chains,
-  publicClient,
   webSocketPublicClient,
-} = configureChains([gnosis], [publicProvider()], {
-  pollingInterval: 30_000,
-  stallTimeout: 5_000,
-  rank: true,
-});
+} = configureChains(
+  [gnosis],
+  [publicProvider()],
+  {
+    pollingInterval: 30_000,
+    stallTimeout: 5_000,
+    rank: true,
+  },
+);
 
 const config = createConfig({
   autoConnect: true,
   connectors: [new MetaMaskConnector({ chains })],
-  publicClient,
+  publicClient: client,
   webSocketPublicClient,
 });
 

--- a/src/providers/wagmi/index.tsx
+++ b/src/providers/wagmi/index.tsx
@@ -11,10 +11,8 @@ import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
 
 // No way to tell what the ethereum request can be so has to be any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type EthereumProvider = { request(...args: any): Promise<any> }
-type WindowWithEthereum = { ethereum: EthereumProvider};
-
-
+type EthereumProvider = { request(...args: any): Promise<any> };
+type WindowWithEthereum = { ethereum: EthereumProvider };
 
 const {
   chains,
@@ -36,7 +34,7 @@ const config = createConfig({
   autoConnect: true,
   connectors: [new MetaMaskConnector({ chains })],
   publicClient: (chain) => {
-    if (typeof window !== 'undefined' && typeof (window as unknown as WindowWithEthereum).ethereum !== 'undefined') {  
+    if (typeof window !== 'undefined' && typeof (window as unknown as WindowWithEthereum).ethereum !== 'undefined') {
       return walletClient;
     }
 


### PR DESCRIPTION
### overview
Sets our public client to the rpc stated in our connected wallet. Fallbacks to wagmi public client if ethereum is not present in window.

#### disclaimer
If ethereum is present in window and the user just has a bad provider, wagmi will go to public client