### PR TITLE
Fix error handling on connecting

### DIFF
--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -232,7 +232,7 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
         if (!error) navigate(`/node/info?apiToken=${apiToken}&apiEndpoint=${apiEndpoint}`);
         props.handleClose();
       }
-    } catch (e) { 
+    } catch (e) {
       // error is handled in redux
     }
   };

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -194,43 +194,46 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
       apiToken,
       apiEndpoint,
     });
-
     dispatch(authActions.resetState());
     dispatch(nodeActions.resetState());
     dispatch(appActions.resetNodeState());
     dispatch(nodeActions.closeMessagesWebsocket());
     dispatch(nodeActions.closeLogsWebsocket());
-    const loginInfo = await dispatch(
-      authActionsAsync.loginThunk({
-        apiEndpoint,
-        apiToken,
-      }),
-    ).unwrap();
-    if (loginInfo) {
-      dispatch(
-        authActions.useNodeData({
+    try {
+      const loginInfo = await dispatch(
+        authActionsAsync.loginThunk({
           apiEndpoint,
           apiToken,
-          localName,
         }),
-      );
-      dispatch(
-        nodeActionsAsync.getAddressesThunk({
-          apiToken,
-          apiEndpoint,
-        }),
-      );
-      dispatch(
-        nodeActionsAsync.getAliasesThunk({
-          apiToken,
-          apiEndpoint,
-        }),
-      );
-      dispatch(nodeActions.setInfo(loginInfo));
-      dispatch(nodeActions.initializeMessagesWebsocket());
-      dispatch(nodeActions.initializeLogsWebsocket());
-      if (!error) navigate(`/node/info?apiToken=${apiToken}&apiEndpoint=${apiEndpoint}`);
-      props.handleClose();
+      ).unwrap();
+      if (loginInfo) {
+        dispatch(
+          authActions.useNodeData({
+            apiEndpoint,
+            apiToken,
+            localName,
+          }),
+        );
+        dispatch(
+          nodeActionsAsync.getAddressesThunk({ payload: {
+            apiToken,
+            apiEndpoint,
+          } }),
+        );
+        dispatch(
+          nodeActionsAsync.getAliasesThunk({
+            apiToken,
+            apiEndpoint,
+          }),
+        );
+        dispatch(nodeActions.setInfo(loginInfo));
+        dispatch(nodeActions.initializeMessagesWebsocket());
+        dispatch(nodeActions.initializeLogsWebsocket());
+        if (!error) navigate(`/node/info?apiToken=${apiToken}&apiEndpoint=${apiEndpoint}`);
+        props.handleClose();
+      }
+    } catch (e) { 
+      // error is handled in redux
     }
   };
 

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -215,10 +215,10 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
           }),
         );
         dispatch(
-          nodeActionsAsync.getAddressesThunk({ payload: {
+          nodeActionsAsync.getAddressesThunk({
             apiToken,
             apiEndpoint,
-          } }),
+          }),
         );
         dispatch(
           nodeActionsAsync.getAliasesThunk({

--- a/src/future-hopr-lib-components/Modal/index.tsx
+++ b/src/future-hopr-lib-components/Modal/index.tsx
@@ -44,7 +44,7 @@ const Modal: React.FC<Props> = (props) => {
     title,
     children,
     maxWidth,
-    disableScrollLock
+    disableScrollLock,
   } = props;
 
   const handleClose = (event: {}) => {

--- a/src/hooks/useWatcher/balances.ts
+++ b/src/hooks/useWatcher/balances.ts
@@ -87,10 +87,10 @@ export const observeNodeBalances = ({
       if (!apiToken || !apiEndpoint) return;
 
       return await dispatch(
-        nodeActionsAsync.getBalancesThunk({ payload: {
+        nodeActionsAsync.getBalancesThunk({ 
           apiEndpoint,
           apiToken,
-        } }),
+        }),
       ).unwrap();
     },
     isDataDifferent: (newNodeBalances) => JSON.stringify(previousState) !== JSON.stringify(newNodeBalances),

--- a/src/hooks/useWatcher/balances.ts
+++ b/src/hooks/useWatcher/balances.ts
@@ -87,7 +87,7 @@ export const observeNodeBalances = ({
       if (!apiToken || !apiEndpoint) return;
 
       return await dispatch(
-        nodeActionsAsync.getBalancesThunk({ 
+        nodeActionsAsync.getBalancesThunk({
           apiEndpoint,
           apiToken,
         }),

--- a/src/hooks/useWatcher/balances.ts
+++ b/src/hooks/useWatcher/balances.ts
@@ -87,10 +87,10 @@ export const observeNodeBalances = ({
       if (!apiToken || !apiEndpoint) return;
 
       return await dispatch(
-        nodeActionsAsync.getBalancesThunk({
+        nodeActionsAsync.getBalancesThunk({ payload: {
           apiEndpoint,
           apiToken,
-        }),
+        } }),
       ).unwrap();
     },
     isDataDifferent: (newNodeBalances) => JSON.stringify(previousState) !== JSON.stringify(newNodeBalances),

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -335,7 +335,7 @@ const LayoutEnhanced = () => {
             }),
           );
           dispatch(
-            nodeActionsAsync.getAddressesThunk({ 
+            nodeActionsAsync.getAddressesThunk({
               apiToken,
               apiEndpoint,
             }),

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -335,10 +335,10 @@ const LayoutEnhanced = () => {
             }),
           );
           dispatch(
-            nodeActionsAsync.getAddressesThunk({ payload: {
+            nodeActionsAsync.getAddressesThunk({ 
               apiToken,
               apiEndpoint,
-            } }),
+            }),
           );
           dispatch(
             nodeActionsAsync.getAliasesThunk({

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -320,33 +320,37 @@ const LayoutEnhanced = () => {
     );
     if (!apiToken) return;
     const useNode = async () => {
-      const loginInfo = await dispatch(
-        authActionsAsync.loginThunk({
-          apiEndpoint,
-          apiToken,
-        }),
-      ).unwrap();
-      if (loginInfo) {
-        dispatch(
-          nodeActionsAsync.getInfoThunk({
-            apiToken,
+      try {
+        const loginInfo = await dispatch(
+          authActionsAsync.loginThunk({
             apiEndpoint,
-          }),
-        );
-        dispatch(
-          nodeActionsAsync.getAddressesThunk({
             apiToken,
-            apiEndpoint,
           }),
-        );
-        dispatch(
-          nodeActionsAsync.getAliasesThunk({
-            apiToken,
-            apiEndpoint,
-          }),
-        );
-        dispatch(nodeActions.initializeMessagesWebsocket());
-        dispatch(nodeActions.initializeLogsWebsocket());
+        ).unwrap();
+        if (loginInfo) {
+          dispatch(
+            nodeActionsAsync.getInfoThunk({
+              apiToken,
+              apiEndpoint,
+            }),
+          );
+          dispatch(
+            nodeActionsAsync.getAddressesThunk({ payload: {
+              apiToken,
+              apiEndpoint,
+            } }),
+          );
+          dispatch(
+            nodeActionsAsync.getAliasesThunk({
+              apiToken,
+              apiEndpoint,
+            }),
+          );
+          dispatch(nodeActions.initializeMessagesWebsocket());
+          dispatch(nodeActions.initializeLogsWebsocket());
+        }
+      } catch (e) {
+        // error is handled on redux
       }
     };
     useNode();

--- a/src/sections/node/info.tsx
+++ b/src/sections/node/info.tsx
@@ -42,10 +42,10 @@ function InfoPage() {
   const fetchInfoData = () => {
     if (apiEndpoint && apiToken) {
       dispatch(
-        actionsAsync.getBalancesThunk({
+        actionsAsync.getBalancesThunk({ payload: {
           apiEndpoint,
           apiToken,
-        }),
+        } }),
       );
       dispatch(
         actionsAsync.getChannelsThunk({
@@ -54,10 +54,10 @@ function InfoPage() {
         }),
       );
       dispatch(
-        actionsAsync.getAddressesThunk({
+        actionsAsync.getAddressesThunk({ payload: {
           apiEndpoint,
           apiToken,
-        }),
+        } }),
       );
       dispatch(
         actionsAsync.getVersionThunk({

--- a/src/sections/node/info.tsx
+++ b/src/sections/node/info.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { useAppDispatch, useAppSelector } from '../../store';
 
 // Mui
@@ -10,7 +9,6 @@ import { useEffect } from 'react';
 import { actionsAsync } from '../../store/slices/node/actionsAsync';
 import { TableExtended } from '../../future-hopr-lib-components/Table/columed-data';
 import { SubpageTitle } from '../../components/SubpageTitle';
-import WithdrawModal from '../../components/Modal/WithdrawModal';
 
 function InfoPage() {
   const dispatch = useAppDispatch();
@@ -42,10 +40,10 @@ function InfoPage() {
   const fetchInfoData = () => {
     if (apiEndpoint && apiToken) {
       dispatch(
-        actionsAsync.getBalancesThunk({ payload: {
+        actionsAsync.getBalancesThunk({
           apiEndpoint,
           apiToken,
-        } }),
+        }),
       );
       dispatch(
         actionsAsync.getChannelsThunk({
@@ -54,10 +52,10 @@ function InfoPage() {
         }),
       );
       dispatch(
-        actionsAsync.getAddressesThunk({ payload: {
+        actionsAsync.getAddressesThunk({
           apiEndpoint,
           apiToken,
-        } }),
+        }),
       );
       dispatch(
         actionsAsync.getVersionThunk({

--- a/src/store/slices/auth/actionsAsync.ts
+++ b/src/store/slices/auth/actionsAsync.ts
@@ -36,27 +36,30 @@ export const loginThunk = createAsyncThunk<
           force: true,
         }),
       ).unwrap();
-            
+
       const addresses = await dispatch(
         nodeActionsAsync.getAddressesThunk({
           payload: {
             apiToken,
             apiEndpoint,
-          }, force: true, 
+          },
+          force: true,
         }),
       ).unwrap();
-  
+
       const minimumNodeBalance = parseEther('0.001');
-  
+
       if (nodeBalances?.native !== undefined && BigInt(nodeBalances.native) < minimumNodeBalance) {
-        return rejectWithValue(`Your xDai balance seems to low to operate the node.\nPlease top up your node.\nAddress: ${addresses?.native}`);
+        return rejectWithValue(
+          `Your xDai balance seems to low to operate the node.\nPlease top up your node.\nAddress: ${addresses?.native}`,
+        );
       }
-  
+
       // stringify to make sure that
       // the error is serializable
       return rejectWithValue('Unknown error: ' + JSON.stringify(e));
     } catch (unknownError) {
-      // getting balance and addresses failed 
+      // getting balance and addresses failed
       // no way to tell if the balance is low
       return rejectWithValue('Error fetching: ' + JSON.stringify(unknownError));
     }
@@ -79,11 +82,11 @@ export const createExtraReducers = (builder: ActionReducerMapBuilder<typeof init
   builder.addCase(loginThunk.rejected, (state, meta) => {
     state.status.connecting = false;
     if (meta.payload) {
-      state.status.error = 'Unable to connect.\n\n' + meta.payload 
-    } else if(meta.error.message) {
-      state.status.error = 'Unable to connect.\n\n' + meta.error.message 
+      state.status.error = 'Unable to connect.\n\n' + meta.payload;
+    } else if (meta.error.message) {
+      state.status.error = 'Unable to connect.\n\n' + meta.error.message;
     } else {
-      state.status.error = 'Unable to connect.\n\n' + 'Unknown error'
+      state.status.error = 'Unable to connect.\n\n' + 'Unknown error';
     }
   });
 };

--- a/src/store/slices/auth/actionsAsync.ts
+++ b/src/store/slices/auth/actionsAsync.ts
@@ -29,20 +29,16 @@ export const loginThunk = createAsyncThunk<
     try {
       const nodeBalances = await dispatch(
         nodeActionsAsync.getBalancesThunk({
-          payload: {
-            apiEndpoint,
-            apiToken,
-          },
+          apiEndpoint,
+          apiToken,
           force: true,
         }),
       ).unwrap();
 
       const addresses = await dispatch(
         nodeActionsAsync.getAddressesThunk({
-          payload: {
-            apiToken,
-            apiEndpoint,
-          },
+          apiToken,
+          apiEndpoint,
           force: true,
         }),
       ).unwrap();

--- a/src/store/slices/auth/actionsAsync.ts
+++ b/src/store/slices/auth/actionsAsync.ts
@@ -26,29 +26,40 @@ export const loginThunk = createAsyncThunk<
     return info;
   } catch (e) {
     // see if connecting error is due to low balance
-    const nodeBalances = await dispatch(
-      nodeActionsAsync.getBalancesThunk({
-        apiEndpoint,
-        apiToken,
-      }),
-    ).unwrap();
-
-    const addresses = await dispatch(
-      nodeActionsAsync.getAddressesThunk({
-        apiToken,
-        apiEndpoint,
-      }),
-    ).unwrap();
-
-    const minimumNodeBalance = parseEther('0.001');
-
-    if (nodeBalances?.native && BigInt(nodeBalances.native) < minimumNodeBalance) {
-      return rejectWithValue(`Your xDai balance seems to low to operate the node. 
-        \n Please top up your node.
-        \n Address: ${addresses?.native}`);
+    try {
+      const nodeBalances = await dispatch(
+        nodeActionsAsync.getBalancesThunk({
+          payload: {
+            apiEndpoint,
+            apiToken,
+          },
+          force: true,
+        }),
+      ).unwrap();
+            
+      const addresses = await dispatch(
+        nodeActionsAsync.getAddressesThunk({
+          payload: {
+            apiToken,
+            apiEndpoint,
+          }, force: true, 
+        }),
+      ).unwrap();
+  
+      const minimumNodeBalance = parseEther('0.001');
+  
+      if (nodeBalances?.native !== undefined && BigInt(nodeBalances.native) < minimumNodeBalance) {
+        return rejectWithValue(`Your xDai balance seems to low to operate the node.\nPlease top up your node.\nAddress: ${addresses?.native}`);
+      }
+  
+      // stringify to make sure that
+      // the error is serializable
+      return rejectWithValue('Unknown error: ' + JSON.stringify(e));
+    } catch (unknownError) {
+      // getting balance and addresses failed 
+      // no way to tell if the balance is low
+      return rejectWithValue('Error fetching: ' + JSON.stringify(unknownError));
     }
-
-    return rejectWithValue(e);
   }
 });
 
@@ -67,8 +78,13 @@ export const createExtraReducers = (builder: ActionReducerMapBuilder<typeof init
   });
   builder.addCase(loginThunk.rejected, (state, meta) => {
     state.status.connecting = false;
-    console.log(meta);
-    state.status.error = 'Unable to connect.\n\n' + JSON.stringify(meta.error);
+    if (meta.payload) {
+      state.status.error = 'Unable to connect.\n\n' + meta.payload 
+    } else if(meta.error.message) {
+      state.status.error = 'Unable to connect.\n\n' + meta.error.message 
+    } else {
+      state.status.error = 'Unable to connect.\n\n' + 'Unknown error'
+    }
   });
 };
 

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -114,11 +114,11 @@ const getAddressesThunk = createAsyncThunk<
       native: string;
     }
   | undefined,
-  { payload: BasePayloadType; force?: boolean },
+  BasePayloadType & {force?: boolean },
   { state: RootState }
 >(
   'node/getAccount',
-  async ({ payload }, {
+  async (payload , {
     rejectWithValue,
     dispatch,
   }) => {
@@ -176,11 +176,11 @@ const getAliasesThunk = createAsyncThunk<GetAliasesResponseType | undefined, Bas
 
 const getBalancesThunk = createAsyncThunk<
   { hopr: string; native: string } | undefined,
-  { payload: BasePayloadType; force?: boolean },
+  BasePayloadType & { force?: boolean },
   { state: RootState; dispatch: ThunkDispatch<RootState, unknown, AnyAction> }
 >(
   'node/getBalances',
-  async ({ payload }, {
+  async (payload, {
     rejectWithValue,
     dispatch,
   }) => {

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -114,11 +114,11 @@ const getAddressesThunk = createAsyncThunk<
       native: string;
     }
   | undefined,
-  BasePayloadType,
+  {payload: BasePayloadType, force?: boolean },
   { state: RootState }
 >(
   'node/getAccount',
-  async (payload: BasePayloadType, {
+  async ({ payload }, {
     rejectWithValue,
     dispatch,
   }) => {
@@ -136,6 +136,10 @@ const getAddressesThunk = createAsyncThunk<
     }
   },
   { condition: (_payload, { getState }) => {
+    if (_payload.force) {
+      return true;
+    }
+    
     const isFetching = getState().node.addresses.isFetching;
     if (isFetching) {
       return false;
@@ -172,11 +176,11 @@ const getAliasesThunk = createAsyncThunk<GetAliasesResponseType | undefined, Bas
 
 const getBalancesThunk = createAsyncThunk<
   { hopr: string; native: string } | undefined,
-  BasePayloadType,
+  {payload: BasePayloadType, force?: boolean },
   { state: RootState; dispatch: ThunkDispatch<RootState, unknown, AnyAction> }
 >(
   'node/getBalances',
-  async (payload: BasePayloadType, {
+  async ({ payload }, {
     rejectWithValue,
     dispatch,
   }) => {
@@ -194,6 +198,10 @@ const getBalancesThunk = createAsyncThunk<
     }
   },
   { condition: (_payload, { getState }) => {
+    if (_payload.force) {
+      return true;
+    }
+
     const isFetching = getState().node.balances.isFetching;
     if (isFetching) {
       return false;

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -114,7 +114,7 @@ const getAddressesThunk = createAsyncThunk<
       native: string;
     }
   | undefined,
-  {payload: BasePayloadType, force?: boolean },
+  { payload: BasePayloadType; force?: boolean },
   { state: RootState }
 >(
   'node/getAccount',
@@ -139,7 +139,7 @@ const getAddressesThunk = createAsyncThunk<
     if (_payload.force) {
       return true;
     }
-    
+
     const isFetching = getState().node.addresses.isFetching;
     if (isFetching) {
       return false;
@@ -176,7 +176,7 @@ const getAliasesThunk = createAsyncThunk<GetAliasesResponseType | undefined, Bas
 
 const getBalancesThunk = createAsyncThunk<
   { hopr: string; native: string } | undefined,
-  {payload: BasePayloadType, force?: boolean },
+  { payload: BasePayloadType; force?: boolean },
   { state: RootState; dispatch: ThunkDispatch<RootState, unknown, AnyAction> }
 >(
   'node/getBalances',

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -114,11 +114,11 @@ const getAddressesThunk = createAsyncThunk<
       native: string;
     }
   | undefined,
-  BasePayloadType & {force?: boolean },
+  BasePayloadType & { force?: boolean },
   { state: RootState }
 >(
   'node/getAccount',
-  async (payload , {
+  async (payload, {
     rejectWithValue,
     dispatch,
   }) => {

--- a/src/store/slices/node/websocketMiddleware.ts
+++ b/src/store/slices/node/websocketMiddleware.ts
@@ -37,6 +37,8 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
         apiEndpoint,
         apiToken,
       } = getState().auth.loginData;
+      const connectedToNode = getState().auth.status.connected;
+      if (!connectedToNode) return;
       const messagesWebsocketStatus = getState().node.messagesWebsocketStatus;
       if (apiEndpoint && apiToken) {
         try {
@@ -80,6 +82,8 @@ const websocketMiddleware: Middleware<object, LocalRootState> = ({
         apiEndpoint,
         apiToken,
       } = getState().auth.loginData;
+      const connectedToNode = getState().auth.status.connected;
+      if (!connectedToNode) return;
       const logsWebsocketStatus = getState().node.logsWebsocketStatus;
       if (apiEndpoint && apiToken) {
         try {


### PR DESCRIPTION
closes #194 

### overview
changed the get loginThunk to catch more errors.

#### changes in redux
Sometimes i would see the error text get rendered twice mainly because the thunk would be in state `isFetching` and the redux condition would fail. So I added a `force` prop which would skip this condition.
```
{ condition: (_payload, { getState }) => {
    if (_payload.force) {
      return true;
    }

    const isFetching = getState().node.balances.isFetching;
    if (isFetching) {
      return false;
    }
  } },
```
