### PR TITLE
Update whole app links and FAQ links

### DIFF
--- a/src/components/Faq/node-faq.tsx
+++ b/src/components/Faq/node-faq.tsx
@@ -15,9 +15,23 @@ const nodeFaq: FaqData = {
         <span>
           You can find the latest version for your device on our docs:
           <br />
-          <br />- For <a href="https://docs.hoprnet.org/node/using-dappnode">Dappnode</a>
+          <br />- For{' '}
+          <a
+            href="https://docs.hoprnet.org/node/using-dappnode"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Dappnode
+          </a>
           <br />
-          <br />- For <a href="https://docs.hoprnet.org/node/using-docker">Docker</a>
+          <br />- For{' '}
+          <a
+            href="https://docs.hoprnet.org/node/using-docker"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Docker
+          </a>
         </span>
       ),
     },
@@ -47,7 +61,14 @@ const nodeFaq: FaqData = {
           <br />
           <br />
           You can read what differentiates each category{' '}
-          <a href="https://docs.hoprnet.org/node/hoprd-commands#info">here</a>.
+          <a
+            href="https://docs.hoprnet.org/node/hoprd-commands#info"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },
@@ -139,7 +160,13 @@ const nodeFaq: FaqData = {
         <span>
           If a large proportion of your connection attempts are failing, there is likely an issue with your node or a
           bug. This is diagnostic information you can pass on for support to one of our ambassadors on Telegram:{' '}
-          <a href="https://t.me/hoprnet">https://t.me/hoprnet</a>
+          <a
+            href="https://t.me/hoprnet"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://t.me/hoprnet
+          </a>
         </span>
       ),
     },
@@ -240,7 +267,11 @@ const nodeFaq: FaqData = {
       content: (
         <span>
           You can view the lifecycle of a payment channel and what the different states mean here:{' '}
-          <a href="https://docs.hoprnet.org/developers/smart-contract#lifecycle-of-payment-channel">
+          <a
+            href="https://docs.hoprnet.org/developers/smart-contract#lifecycle-of-payment-channel"
+            target="_blank"
+            rel="noreferrer"
+          >
             https://docs.hoprnet.org/developers/smart-contract#lifecycle-of-payment-channel
           </a>
         </span>

--- a/src/components/Faq/node-faq.tsx
+++ b/src/components/Faq/node-faq.tsx
@@ -48,7 +48,15 @@ const nodeFaq: FaqData = {
         <span>
           You must have your node approved to join the network by having an eligible associated staking address and
           being approved by the HOPR association to join the network, as it is currently permissioned. You can join the
-          network by creating a safe <a href="#">here</a>.
+          network by creating a safe{' '}
+          <a
+            href="/staking/onboarding"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },

--- a/src/components/Faq/staking-alerts.tsx
+++ b/src/components/Faq/staking-alerts.tsx
@@ -6,7 +6,7 @@ type FaqElement = {
 
 type FaqData = Record<string, FaqElement[]>;
 
-const stakingAlerts: FaqData = { '/hub/onboarding#15': [
+const stakingAlerts: FaqData = { '/staking/onboarding#15': [
   {
     id: 1,
     title: 'Funds at risk',

--- a/src/components/Faq/staking-faq.tsx
+++ b/src/components/Faq/staking-faq.tsx
@@ -468,7 +468,7 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           Make sure your allowance aligns with your node strategy and is not draining your tokens or preventing you from
-          producing well-connected nodes. You can always change your node allowance <a href="#">here</a>.{' '}
+          producing well-connected nodes. You can always change your node allowance <a href="#node">here</a>.{' '}
           {/*FIXME: put link to specific page */}
         </span>
       ),

--- a/src/components/Faq/staking-faq.tsx
+++ b/src/components/Faq/staking-faq.tsx
@@ -27,7 +27,14 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           You can find the best options for buying HOPR, DAI, xDAI and xHOPR in our{' '}
-          <a href="https://docs.hoprnet.org/staking/how-to-get-hopr">docs</a>.
+          <a
+            href="https://docs.hoprnet.org/staking/how-to-get-hopr"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs
+          </a>
+          .
         </span>
       ),
     },
@@ -43,7 +50,14 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           You can convert your xHOPR to wxHOPR by using our wrapper on the{' '}
-          <a href="https://wrapper.hoprnet.org/">staking hub</a>.
+          <a
+            href="https://wrapper.hoprnet.org/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            staking hub
+          </a>
+          .
         </span>
       ),
     },
@@ -101,7 +115,14 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           You can find the best options for buying HOPR, DAI, xDAI and xHOPR in our{' '}
-          <a href="https://docs.hoprnet.org/staking/how-to-get-hopr">docs</a>.
+          <a
+            href="https://docs.hoprnet.org/staking/how-to-get-hopr"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs
+          </a>
+          .
         </span>
       ),
     },
@@ -111,7 +132,14 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           You can convert your xHOPR to wxHOPR by using our wrapper on the{' '}
-          <a href="https://wrapper.hoprnet.org/">staking hub</a>.
+          <a
+            href="https://wrapper.hoprnet.org/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            staking hub
+          </a>
+          .
         </span>
       ),
     },
@@ -129,7 +157,14 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           You will need to install Docker on your device to complete this installation. Follow{' '}
-          <a href="#">these instructions</a> if you don't have Docker installed.
+          <a
+            href="https://docs.hoprnet.org/node/using-docker#installing-docker"
+            target="_blank"
+            rel="noreferrer"
+          >
+            these instructions
+          </a>{' '}
+          if you don't have Docker installed.
         </span>
       ),
     },
@@ -138,7 +173,15 @@ const stakingFaq: FaqData = {
       title: 'Install Node',
       content: (
         <span>
-          You can view a complete breakdown of how to install a HOPR node using Docker <a href="#">here</a>.
+          You can view a complete breakdown of how to install a HOPR node using Docker{' '}
+          <a
+            href="https://docs.hoprnet.org/node/using-docker"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },
@@ -147,7 +190,15 @@ const stakingFaq: FaqData = {
       title: 'Adding your IP address',
       content: (
         <span>
-          You will need to edit the Docker command to include your public IP address. To find your IP address and edit the command correctly follow the instructions <a href="#">here</a>
+          You will need to edit the Docker command to include your public IP address. To find your IP address and edit
+          the command correctly follow the instructions{' '}
+          <a
+            href="https://docs.hoprnet.org/node/using-docker#find-your-ip-address"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
         </span>
       ),
     },
@@ -204,12 +255,6 @@ const stakingFaq: FaqData = {
       content:
         'Setting it too high may result in a drainage of funds if your node is ever compromised, but a sufficient amount is needed in order to create a well connected node that can maximize its APY. You are free to choose your own risk profile but we recommend using the default value as it is more than sufficient to fund a well connected node.',
     },
-    {
-      id: 3,
-      title: 'Funds at risk',
-      content:
-        'If your node is ever compromised it may lead to your entire allowance of wxHOPR being drained. Please set a reasonable allowance, and use our default value as a guideline.',
-    },
   ],
   '/steps/update-your-node': [
     {
@@ -221,7 +266,15 @@ const stakingFaq: FaqData = {
           setup.
           <br />
           <br />- For Dappnode users, click <a href="#">here</a> for the steps.
-          <br />- Docker users, find your instructions <a href="#">here</a>.
+          <br />- Docker users, find your instructions{' '}
+          <a
+            href="https://docs.hoprnet.org/node/using-docker#updating-to-a-new-release"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },
@@ -245,7 +298,7 @@ const stakingFaq: FaqData = {
         'One xDAI is sufficient to start running a node without any concerns. A lower amount may lead to insufficient funds for on-chain transactions.',
     },
   ],
-  '/steps/stake': [
+  'send wxHopr to safe (stake in figma)': [
     {
       id: 1,
       title: 'Token addresses',
@@ -270,14 +323,21 @@ const stakingFaq: FaqData = {
       ),
     },
   ],
-  '/steps/xdai-to-safe': [
+  'additional xdai to safe': [
     {
       id: 1,
       title: 'Buying xDAI & HOPR',
       content: (
         <span>
           You can find the best options for buying HOPR, DAI, xDAI and xHOPR in our{' '}
-          <a href="https://docs.hoprnet.org/staking/how-to-get-hopr">docs</a>.
+          <a
+            href="https://docs.hoprnet.org/staking/how-to-get-hopr"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs
+          </a>
+          .
         </span>
       ),
     },
@@ -294,13 +354,26 @@ const stakingFaq: FaqData = {
       title: 'Where can I buy xHOPR?',
       content: (
         <span>
-          You can find the best options for buying HOPR, DAI, xDAI and xHOPR in our{' '}
-          <a href="https://docs.hoprnet.org/staking/how-to-get-hopr">docs</a>.
+          You can find the best options for buying HOPR, DAI, xDAI and xHOPR in{' '}
+          <a
+            href="https://docs.hoprnet.org/staking/how-to-get-hopr"
+            target="_blank"
+            rel="noreferrer"
+          >
+            our docs
+          </a>
+          .
         </span>
       ),
     },
+    {
+      id: 2,
+      title: 'What is wrapping?',
+      content:
+        'Wrapping a token allows it to be used on a non-native blockchain. Similar to switching a dollar for four quarters so you can use the machine that only takes quarters. You need to wxHOPR to fund payment channels in the HOPR network, but you can always swap the wxHOPR back for an equal amount of xHOPR ot HOPR.',
+    },
   ],
-  '/dev-pages/staking-screen': [
+  '/staking/dashboard#staking': [
     {
       id: 1,
       title: 'How much xDAI should I deposit',
@@ -313,7 +386,14 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           You can find the best options for buying HOPR, DAI, xDAI and xHOPR in our{' '}
-          <a href="https://docs.hoprnet.org/staking/how-to-get-hopr">docs</a>.
+          <a
+            href="https://docs.hoprnet.org/staking/how-to-get-hopr"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs
+          </a>
+          .
         </span>
       ),
     },
@@ -323,7 +403,15 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           This will vary depending on how many nodes are in the network, how much wxHOPR you have staked and how many
-          nodes you are running. You can view a complete breakdown of the economic model <a href="#">here</a>.
+          nodes you are running. You can view a complete breakdown of the economic model{' '}
+          <a
+            href="https://twitter.com/hoprnet/status/1696539901305790534"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },
@@ -341,7 +429,7 @@ const stakingFaq: FaqData = {
       ),
     },
   ],
-  '/dev-pages/node-added': [
+  '/staking/dashboard#node': [
     {
       id: 1,
       title: 'How much xDAI should I deposit?',
@@ -359,7 +447,15 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           After creating and funding your safe, you will need to register your safe address on to the waitlist using
-          this <a href="#">form</a>.<br />
+          this{' '}
+          <a
+            href="https://cryptpad.fr/form/#/2/form/view/K3KSF-UAM-mLjUCs4w3Cruu4wZeOdwQFLNG1aYqrjbg/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            form
+          </a>
+          .<br />
           <br />
           Nodes are onboarded into the HOPR network in a first come, first serve basis. So fill out the form as soon as
           possible if you haven't already.
@@ -372,7 +468,8 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           Make sure your allowance aligns with your node strategy and is not draining your tokens or preventing you from
-          producing well-connected nodes. You can always change your node allowance <a href="#">here</a>.
+          producing well-connected nodes. You can always change your node allowance <a href="#">here</a>.{' '}
+          {/*FIXME: put link to specific page */}
         </span>
       ),
     },
@@ -382,10 +479,24 @@ const stakingFaq: FaqData = {
       content: (
         <span>
           To remove your node from your safe, first, execute the removeNode(address nodeAddress) function on the{' '}
-          <a href="#">NodeManagementModule contract</a>.<br />
+          <a
+            href="https://gnosisscan.io/address/0xB7397C218766eBe6A1A634df523A1a7e412e67eA#writeContract"
+            target="_blank"
+            rel="noreferrer"
+          >
+            NodeManagementModule contract
+          </a>
+          .<br />
           <br />
           Then remove the node as a delegate from the safe. You can view how to do this two-step procedure in our docs{' '}
-          <a href="#">here</a>.
+          <a
+            href="https://docs.hoprnet.org/node/using-hopr-admin#remove-your-node"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },
@@ -394,67 +505,18 @@ const stakingFaq: FaqData = {
       title: 'How is node health calculated?',
       content: (
         <span>
-          It is calculated using the network's heartbeat mechanism.\n\nYou can read what differentiates each category{' '}
-          <a href="https://docs.hoprnet.org/node/hoprd-commands#info">here</a>.
-        </span>
-      ),
-    },
-  ],
-  '/dev-pages/no-node': [
-    {
-      id: 1,
-      title: 'How much xDAI should I deposit?',
-      content:
-        'Your node can be funded and run successfully with 1 xDAI. Depositing more in your safe will make refunding your node easier but in general, node running with HOPR does not require much xDAI.',
-    },
-    {
-      id: 2,
-      title: 'Suggested node strategy',
-      content: 'Not defined TBD',
-    },
-    {
-      id: 3,
-      title: 'Waitlist status and policy',
-      content: (
-        <span>
-          After creating and funding your safe, you will need to register your safe address on to the waitlist using
-          this <a href="#">form</a>.<br />
+          It is calculated using the network's heartbeat mechanism.
           <br />
-          Nodes are onboarded into the HOPR network in a first come, first serve basis. So fill out the form as soon as
-          possible if you have't already.
-        </span>
-      ),
-    },
-    {
-      id: 4,
-      title: 'Managing wxHOPR allowance',
-      content: (
-        <span>
-          Make sure your allowance aligns with your node strategy and is not draining your tokens or preventing you from
-          producing well-connected nodes. You can always change your node allowance <a href="#">here</a>.
-        </span>
-      ),
-    },
-    {
-      id: 5,
-      title: 'Remove node from safe',
-      content: (
-        <span>
-          To remove your node from your safe, first, execute the removeNode(address nodeAddress) function on the{' '}
-          <a href="#">NodeManagementModule contract</a>.<br />
           <br />
-          Then remove the node as a delegate from the safe. You can view how to do this two-step procedure in our docs{' '}
-          <a href="#">here</a>.
-        </span>
-      ),
-    },
-    {
-      id: 6,
-      title: 'How is node health calculated?',
-      content: (
-        <span>
-          It is calculated using the network's heartbeat mechanism.\n\nYou can read what differentiates each category{' '}
-          <a href="https://docs.hoprnet.org/node/hoprd-commands#info">here</a>.
+          You can read what differentiates each category{' '}
+          <a
+            href="https://docs.hoprnet.org/node/hoprd-commands#info"
+            target="_blank"
+            rel="noreferrer"
+          >
+            here
+          </a>
+          .
         </span>
       ),
     },

--- a/src/future-hopr-lib-components/Layout/footer.jsx
+++ b/src/future-hopr-lib-components/Layout/footer.jsx
@@ -111,11 +111,11 @@ const Addresses = styled.div`
 const links = [
   {
     name: 'Terms of Service',
-    link: 'https://hoprnet.org/disclaimer',
+    link: '/tos',
   },
   {
     name: 'Privacy Policy',
-    link: 'https://hoprnet.org/disclaimer',
+    link: '/privacy-notice',
   },
 ];
 
@@ -225,6 +225,8 @@ const Footer = (props) => {
                 key={i}
                 title={x.name}
                 href={x.link}
+                target="_blank"
+                rel="noreferrer"
               >
                 {x.name}
               </a>

--- a/src/pages/PrivacyNotice.tsx
+++ b/src/pages/PrivacyNotice.tsx
@@ -1,0 +1,397 @@
+import styled from '@emotion/styled';
+import Section from '../future-hopr-lib-components/Section';
+
+const StyledContainer = styled.div`
+  align-items: center;
+  text-align: justify;
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  max-width: 1080px;
+  padding: 2rem;
+`;
+
+const BigTitle = styled.h2`
+  color: #414141;
+  font-size: 80px;
+  font-weight: 400;
+  margin-block: 0rem;
+  text-transform: uppercase;
+  padding-top: 2rem;
+  text-align: center;
+`;
+
+const Title = styled.h2`
+  color: #414141;
+  font-size: 60px;
+  font-weight: 400;
+  margin-block: 0rem;
+  text-transform: uppercase;
+  text-align: left;
+  width: 100%;
+  /* padding-top: 2rem; */
+`;
+
+const Description = styled.p`
+  color: #414141;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  max-width: 74ch;
+  a {
+    color: #007bff; /* Set the desired color for links */
+    text-decoration: underline;
+  }
+`;
+
+const PrivacyNotice = () => {
+  return (
+    <Section
+      center
+      fullHeightMin
+    >
+      <StyledContainer>
+        <BigTitle>Privacy Notice of HOPR Services Ltd.</BigTitle>
+        <br /> <br />
+        <Title>I. General Information</Title>
+        <Description>
+          HOPR Services Ltd., Bleicherweg 33, 8002 Zürich, Switzerland ("we", "us", or "HOPR") is dedicated to improving
+          data privacy and reducing reliance on personal data. This Privacy Notice ("Notice") shows what kind of
+          personal data we process and in what manner. However, please note that circumstances on how we collect and
+          process Your personal data may change, and thus, we may update this Notice from time to time to reflect
+          current circumstances. An actual version of this Notice is available on our website at
+          <a
+            href="https://hoprnet.org/disclaimer"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://hoprnet.org/disclaimer
+          </a>
+          .
+          <br />
+          <br />
+          We want to process as little personal information as possible when our customers, business partners and others
+          ("You") use our services. We may inform You about further processing of Your data separately, for example, in
+          consent forms, terms and conditions, additional privacy notices, forms and other notices. We use the word
+          «data» here interchangeably with «personal data».
+          <br />
+          <br />
+          If You provide information to us about any person other than Yourself, Your employees, counterparties,
+          business partners, advisors or Your suppliers, You must ensure that the data is accurate, that they understand
+          how their information will be used, and that they have given their permission for You to disclose it to us and
+          for You to allow us, and our outsourced service providers, to use it.
+        </Description>
+        <Title>II. Name and Address of the Controller</Title>
+        <Description>
+          The responsible person for processing Your data under this Privacy Notice («Controller») unless we tell You
+          otherwise in an individual case is:
+          <br />
+          <br />
+          HOPR Services Ltd.
+          <br />
+          Bleicherweg 33
+          <br />
+          8002 Zürich
+          <br />
+          e-mail: info@hoprnet.org
+        </Description>
+        <Title>III. Date Categories</Title>
+        <Description>
+          Depending on the reason for the processing, we process different data about You. Much of the data set out in
+          this Section is provided to us by You (e.g. forms, communication contracts, website, etc.), and You are not
+          obliged to disclose data to us. However, if You wish to enter into contracts with us or use our services, You
+          must provide us with certain data as part of Your contractual obligation under the relevant contract. When
+          using our website, processing technical data cannot be avoided, and when You wish to gain access to certain
+          systems or buildings, You must also provide us with registration data.
+          <br />
+          <br />
+          When visiting our website{' '}
+          <a
+            href="https://rpch.net/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://rpch.net/
+          </a>{' '}
+          incl. any subsite, we process:
+        </Description>
+        <Title>1. Technical Data</Title>
+        <Description>
+          When You access and visit our website, technical data is collected, for example, Your IP- address, type of
+          browser, type of device, access date, time and duration, and websites that You access. Note that Fathom
+          Analytics or Vercel never saves your raw IP address and User Agent, and we do not have any access to your IP
+          address. Unique visitors are identified via SHA256 hashes to guarantee Your privacy. Technical data is
+          recorded in logs with records of the use of our systems. We generally keep technical data for 24 hours.
+          Technical data, as such, does not permit drawing conclusions about Your identity.
+        </Description>
+        <Title>2. Social media buttons/tools</Title>
+        <Description>
+          We have integrated various social media buttons on our website, allowing You to connect to our social media
+          presence on these platforms and get further insights into how our products are set up and work. We may only
+          process Your data if You click on these buttons, log in to Your own account on these platforms or register or
+          behave otherwise to access it. By clicking on these buttons, You agree that personal data may be collected and
+          processed, which may also happen by these social media providers located abroad (e.g. the USA), on their sole
+          and own discretion and responsibility. The social media platform may store the data collected about You as
+          usage profiles and use them for purposes of advertising, market research and/or demand-oriented design of its
+          platform. Such an evaluation is carried out in particular (also for non-logged-in users) to display targeted
+          advertising and inform other users of the social media platform about Your activities on our website. Your
+          connection to a social media platform, the data transfers between the network and Your system and Your
+          interactions on this platform are subject exclusively to the privacy notices of the respective platform. For
+          further information on the purpose and scope of data collection and processing by the social media platform,
+          please review the privacy notices of these social media platforms. You will also receive further information
+          about Your rights and setting options for protecting Your privacy.
+        </Description>
+        <Title>3. GitHub</Title>
+        <Description>
+          We have also integrated a GitHub button, which links You directly to this platform. GitHub servers may collect
+          and save information/data regarding the pages You view, the referring site, Your IP address and
+          information/data about Your device, session information, the date and time of each request, and telemetry data
+          (i.e., information about how a specific feature or service is performing) regarding Your use of other
+          features, Your interaction with GitHub and functionality of GitHub's service. They use this information/data
+          to provide, administer, analyze, manage, and operate their service. We do not collect, store, or process the
+          information and/or data collected by GitHub. For more information about the information/data GitHub collects
+          and how it uses this information/data, please visit GitHub's privacy policies.
+        </Description>
+        <Title>4. Communication</Title>
+        <Description>
+          When You contact us via the online contact form, the Order Form, by e-mail, phone, chat, letter or by any
+          other means of communication, we collect the data exchanged between You and us, including Your contact details
+          and the metadata of the communication.
+        </Description>
+        <Title>5. Services</Title>
+        <Description>
+          When You wish to interact with us in order to receive our services, we process The data that You provide to us
+          voluntarily when getting in touch with us via our communication channels (including our website), from parties
+          You work for, from third parties such as contractual partners, and maybe also from public sources. We process
+          Your data if You are a customer or other business contact or work for one or because we wish to address You
+          for your own purposes or for the purposes of a contractual partner as part of marketing or advertising
+          measures. To conclude a contract with us, You are required to fulfil our Service Order Form, including various
+          personal data we need to process Your service order and perform subsequent contracts with You, which may
+          include Your name, Your project, address/country of domicile, user name and address You use to register,
+          contact person name, e-mail address of a contact person, (billing) address, payment data (method, currency,
+          bank etc., services we provide You with and terms related thereto as well as Know Your Customer (KYC) data,
+          Know Your Business (KYB) data and further data relating to fraud prevention and the combating of money
+          laundering and terrorist financing, export restrictions, sanctions and embargoes. Performing the contract, we
+          may process data such as the calls of requests and your unique client ID. We generally keep this data from the
+          last exchange between us for ten years, but at least from the end of the contract. This period may be longer
+          if required for evidentiary purposes, to comply with legal or contractual requirements, or for technical
+          reasons. For contacts used only for marketing and advertising, the period is usually much shorter, usually at
+          most 2 years from the last contact.
+        </Description>
+        <Title>6. Other Data</Title>
+        <Description>
+          Other data may be processed in relation to administrative or judicial proceedings for security reasons, events
+          or campaigns and monitoring of our physical and IT infrastructure and systems or other situations where we
+          have a reason to protect our legitimate interest. The retention period for this data depends on the processing
+          purpose and is limited to what is necessary.
+        </Description>
+        <Title>IV. Purposes of the Processing</Title>
+        <Description>
+          We process Your data for the purposes explained below. These purposes and their objectives represent the
+          interests of us and potentially of third parties.
+          <ul>
+            <li>
+              Website maintenance and optimization: We have an interest in providing You with a well-functioning website
+              with certain functionalities. We know through which provider You access our offerings (and therefore also
+              the region) because of the IP address, but usually, this does not tell us who You are because Fathom
+              Analytics does not store or show any IP addresses. When you access the website, a hash is generated that
+              anonymizes your personal data (IP address) while giving us minimal technical data (region, device) that we
+              can see.
+            </li>
+            <li>
+              Communication: We process Your data to communicate with You, particularly when You contact us to respond
+              to Your queries or when You exercise Your rights. For this purpose, we use, in particular, communication
+              data, contract data and registration data. We keep this data to document our communication with You for
+              training purposes and quality assurance.
+            </li>
+            <li>
+              Performance of a Contract: We process Your data for entering into a contract with You, perform and
+              administer it and provide You with our service. For this purpose, we process communication, contract data,
+              and any other You provide or request us to process it. This might include data about third parties, e.g.
+              if You order products or services for the benefit of a third party (e.g. Your employer). This also
+              includes data about potential customers we receive from communicating with You at a trade fair or any
+              other business event. As regards the conclusion of a contract, we use this data to assess Your
+              creditworthiness and to open up a business relationship with You.
+            </li>
+            <li>
+              Marketing and Relationship Management: We process Your data for marketing and relationship management
+              purposes (e.g. customer relationship management system (CRM).
+            </li>
+            <li>
+              Risk Management, Corporate Governance and Business Development, Product/Service Improvement and
+              Innovation: We process Your data for market research and to improve our products and services (including
+              our website), and, as part of our risk management and corporate government, in order to protect us from
+              criminal or abusive activity. We might sell businesses, parts of businesses or companies to others or,
+              acquire them from others or enter into partnerships, and this might result in the exchange and processing
+              of data based on Your consent, if necessary. This includes also data processing to protect our IT- and
+              system infrastructure.
+            </li>
+            <li>
+              Compliance with Law: We process Your data to comply with legal requirements, e.g. money laundering and
+              terrorist financing, tax obligations, «Know Your Customer» (KYC) requirements or as otherwise required by
+              law and legal authorities.
+            </li>
+          </ul>
+        </Description>
+        <Title>V. Legal Basis for Processing Your Data</Title>
+        <Description>
+          Where required, we rely on a legal basis for processing Your Data. Where we ask for Your consent, we process
+          Your data based on such consent. You may withdraw Your consent at any time with effect for the future by
+          providing us written notice (e-mail sufficient) to info@hoprnet.org. Withdrawal of Your consent does not
+          affect the lawfulness of the processing that we have carried out prior to Your withdrawal, nor does it affect
+          the processing of Your data based on other processing grounds. Otherwise, we may process Your data in the
+          context of (i) a contractual obligation, (ii) a legal obligation, (iii) a vital interest of the data subject
+          or of another natural person, (iv) to perform a public task, or (v) a legitimate interest, which includes
+          compliance with applicable law and the marketing of our products and services, the interest in better
+          understanding our markets and in managing and further developing our company, including its operations, safely
+          and efficiently.
+        </Description>
+        <Title>VI. Your Rights</Title>
+        <Description>
+          You have various rights in relation to our processing of Your personal data, depending on the applicable data
+          protection law:
+          <ul>
+            <li>
+              Right of Access: You have the right to request a copy of the personal data that we hold about You. There
+              are exceptions to this right, so that access may be denied if, for example, making the information
+              available to You would reveal personal data about another person or if we are legally prevented from
+              disclosing such information.
+            </li>
+            <li>
+              Right to Rectification and Restriction: We aim to keep Your personal data accurate, current, and complete.
+              We encourage You to contact us to let us know if any of Your personal data is not accurate or changes so
+              that we can keep Your personal data up to date. You have further the right to ask us to restrict the
+              processing of Your personal information in certain circumstances.
+            </li>
+            <li>
+              Right to Erasure: You have the right to require us to erase Your personal data when the personal data is
+              no longer necessary for the purposes for which it was collected or when, among other things, Your personal
+              data has been unlawfully processed.
+            </li>
+            <li>
+              Right to Data Portability: You have the right to ask that we transfer the personal information You gave us
+              to another controller or to You in certain circumstances.
+            </li>
+            <li>
+              Right to Withdraw Consent: Where we process data based on Your consent, You have the right to withdraw
+              Your consent. Once we have received notification that You have withdrawn Your consent, we will no longer
+              process Your information for the purpose(s) to which You originally consented unless there is another
+              legal ground for the processing.
+            </li>
+            <li>
+              Right to Complain: If you believe that Your data protection rights have been violated, You can contact the
+              competent supervisory authority, the Federal Data Protection and Information Commissioner (FDPIC) and the
+              European Union. Your local data protection supervisory authority is responsible for Your concern (see more
+              details here:{' '}
+              <a
+                href="https://edpb.europa.eu/about-edpb/about-edpb/members_en"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://edpb.europa.eu/about-edpb/about-edpb/members_en
+              </a>
+              ).
+            </li>
+            <li>
+              Right to Object: Under applicable data protection law, You have the right to object at any time to the
+              processing of personal data pertaining to You under certain circumstances, in particular where Your data
+              is processed in the public interest, on the basis of a balance of interests or for direct marketing
+              purposes.
+            </li>
+          </ul>
+          If You would like to exercise the above-mentioned rights, don't hesitate to contact us at info@hoprnet.org.
+          Please note that we need to identify You to prevent misuse, e.g. by means of a copy of Your ID card or
+          passport, unless identification is possible otherwise.
+        </Description>
+        <Title>VII. Data Security</Title>
+        <Description>
+          We take appropriate organizational and technical measures to prevent Your personal data from being
+          accidentally lost, used or accessed in an unauthorized way, altered or disclosed. However, we and Your
+          personal data can still become victims of cyber-attacks, cybercrime, brute force, hacker attacks and further
+          fraudulent and malicious activity, including but not limited to viruses, forgeries, malfunctions and
+          interruptions, which are out of our control and responsibility.
+        </Description>
+        <Title>VIII. Disclosure of Data to Third Parties</Title>
+        <Description>
+          In order to perform our contracts, fulfil our legal obligations, protect our legitimate interest and the other
+          purposes and legal grounds set out above, we may disclose Your data to third parties, in particular to the
+          following categories of recipients:
+          <ul>
+            <li>
+              Wallet Provider: Please kindly note that any data processing in this context is not in our area of
+              responsibility. Your data handling in the role of a wallet provider, a provider in relation to such wallet
+              service or Your interactions with any third-party wallet provider is solely and exclusively governed by
+              the applicable terms of service and privacy policy of the walled provider and is unaffected by this Notice
+              and vice versa. This Notice is not applicable and/or subject to any data privacy rules of such third-party
+              provider. However, please note that we have - by design - no access to any of Your information on the
+              chain.
+            </li>
+            <li>
+              Service Providers: We may share Your information with service providers and business partners around the
+              world with whom we collaborate to fulfil the above purposes (e.g. IT providers, shipping companies,
+              advertising service providers, security companies, banks, insurance companies, telecommunication
+              companies, credit information agencies, address verification provider, lawyers) or who we engage to
+              process personal data for any of the purposes listed above on our behalf and in accordance with our
+              instructions only.
+            </li>
+            <li>
+              Legal Authorities: If legally obliged or entitled to make disclosures or if it appears necessary to
+              protect our interests, we may disclose Your data to courts, law enforcement authorities, regulators,
+              government officials or other legal authorities in Switzerland or abroad, e.g. in criminal investigations
+              and legal proceedings including alternative dispute resolution as well as to prevent and combat money
+              laundering and terrorist financing (e.g. duties in the event of a suspicion of money laundering, duty to
+              report to Money Laundering Report-ing Offices Switzerland or abroad) or due to further reporting duties.
+            </li>
+          </ul>
+        </Description>
+        <Title>IX. Transfer of Data Abroad</Title>
+        <Description>
+          As we have explained in Section VIII, we disclose data to other parties, not all of them located in
+          Switzerland. This also applies to our presence on social networks/platforms as described below in Section X.
+          Your data may be processed in the European Economic Area (EEA) and, in exceptional circumstances, also in
+          countries outside the EEA and around the world, which includes countries that do not provide the same level of
+          data protection as Switzerland or the EEA and are not recognized as providing an adequate level of data
+          protection. We only transfer data to these countries when it is necessary for the performance of a contract or
+          for the exercise or defence of legal claims, or if such transfer is based on Your explicit consent or subject
+          to safeguards that assure the protection of Your data, such as the European Commission approved standard
+          contractual clauses.
+        </Description>
+        <Title>X. Cookies</Title>
+        <Description>
+          We use cookies on our website [and may allow certain third parties to do so as well]. When you visit our
+          website, cookies are small files that Your browser automatically creates and that are stored on Your device
+          (laptop, tablet, smartphone, etc.). However, depending on the purpose of these cookies, we may ask for Your
+          express prior consent before they are used. You can withdraw Your consent under the same link at any time. You
+          can also set Your browser to block or deceive certain types of cookies or alternative technologies or to
+          delete existing cookies, adding software to Your browser that blocks certain third-party tracking. Please
+          learn more on the help pages of Your or on the websites of the third parties.
+          <ul>
+            <li>
+              Necessary Cookies: Necessary cookies are necessary for the functioning of the website or for certain
+              features. They make the use of our website more pleasant for You. For example, they help make a website
+              usable by enabling basic functions such as page navigation and access to secure areas of the website. They
+              also ensure that You can move between pages without losing information entered in a form and stay logged
+              in. These cookies exist temporarily only («session cookies») and are automatically deleted after leaving
+              our pages. If You block them, the website may not work properly. Other cookies are necessary for the
+              server to store options or information (which You have entered) beyond a session (i.e. a visit to the
+              website) if You use this function (for example, language settings, consents, automatic login
+              functionality, etc.). These cookies have an expiration date of up to [12] months. The legal basis for such
+              cookies is our legitimate interest according to providing You with all functions of our website. A list of
+              necessary cookies is provided in our Consent Management Tool.
+            </li>
+          </ul>
+        </Description>
+        <Title>XI. How Long We Keep Your Personal Data</Title>
+        <Description>
+          We only process Your data for as long as necessary to fulfil the purposes we collected it for, including for
+          the purposes of complying with legal retention requirements and, where required to assert or defend against
+          legal claims, until the end of the relevant retention period or until the claims in question have been
+          settled. Upon expiry of the applicable retention period, we will securely destroy Your data in accordance with
+          applicable laws and regulations. Contract data
+        </Description>
+      </StyledContainer>
+    </Section>
+  );
+};
+
+export default PrivacyNotice;

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,0 +1,165 @@
+import styled from '@emotion/styled';
+import Section from '../future-hopr-lib-components/Section';
+
+const StyledContainer = styled.div`
+  align-items: center;
+  text-align: justify;
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  max-width: 1080px;
+  padding: 2rem;
+`;
+
+const BigTitle = styled.h2`
+  color: #414141;
+  font-size: 80px;
+  font-weight: 400;
+  margin-block: 0rem;
+  text-transform: uppercase;
+  padding-top: 2rem;
+`;
+
+const Title = styled.h2`
+  color: #414141;
+  font-size: 60px;
+  font-weight: 400;
+  margin-block: 0rem;
+  text-transform: uppercase;
+  text-align: center;
+
+  width: 100%;
+  /* padding-top: 2rem; */
+`;
+
+const Description = styled.p`
+  color: #414141;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  max-width: 74ch;
+  a {
+    color: #007bff; /* Set the desired color for links */
+    text-decoration: underline;
+  }
+`;
+
+const TermsOfService = () => {
+  return (
+    <Section
+      center
+      fullHeightMin
+    >
+      <StyledContainer>
+        <BigTitle>Terms of Service</BigTitle>
+        <br /> <br />
+        <Title>Who we are</Title>
+        <Description>
+          We are HOPR Services Ltd., Bleicherweg 33, 8002 Zürich, Switzerland, and we operate the website{' '}
+          <a
+            href="https://hub.hoprnet.org/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://hub.hoprnet.org/
+          </a>
+        </Description>
+        <Title>Understanding our Terms of Service</Title>
+        <Description>
+          These terms of service (" Website Terms of Service / Terms of Service ") set out the legal terms and
+          conditions on which we allow you to access our website. By accessing, browsing or otherwise using our website,
+          you accept these Terms of Service without limitation or qualification. If you do not accept these Terms of
+          Service, you are not entitled to access or use the website, and you should leave the website immediately.
+          <br />
+          <br />
+          When we refer to "we", "us", or "our", we mean HOPR Services Ltd. When we refer to "you" or "your", we mean
+          you, the person accessing or using our website.
+        </Description>
+        <Title>Our Website</Title>
+        <Description>
+          Our website is made available free of charge. We do not guarantee that our website, or any content, will
+          always be available or uninterrupted. Access to our Website is permitted on a temporary basis. We may suspend,
+          withdraw, discontinue or change all or any part of our website without notice. We will not be liable to you
+          if, for any reason, our website is unavailable at any time or for any period. We may update the website and/or
+          change its content at any time.
+          <br />
+          <br />
+          You are responsible for making all arrangements necessary for you to have access to our website. You are also
+          responsible for ensuring that all persons who access our website through your internet connection are aware of
+          these Terms of Service and that they comply with them.
+          <br />
+          <br />
+          We do not guarantee that the website or any content on it will be free from errors or omissions. We use
+          reasonable efforts to include only accurate and up-to-date information on the website. However, we make no
+          representations, warranties or guarantees concerning such information, whether express or implied.
+          <br />
+          <br />
+          The website and the content on it are provided for general information purposes only. They are not intended to
+          amount to advice on which you should rely. You must obtain professional or specialist advice before taking or
+          refraining from any action based on the content on our website.
+        </Description>
+        <Title>Intellectual Property Rights</Title>
+        <Description>
+          We are the owner or licensee of all intellectual property rights in the website and its entire content. This
+          includes, in particular but without limitation, page headers, texts, graphics, logos, images, digital
+          downloads and the selection and arrangement of the same. You agree not to take any action(s) inconsistent with
+          such ownership interests.
+        </Description>
+        <Title>Limitation of Liability</Title>
+        <Description>
+          Our liability is excluded to the maximum extent permitted by law. In particular, but without limitation, we
+          are not liable for
+          <ul>
+            <li>Indirect or consequential damages, such as loss of profits, savings or claims by third parties</li>
+            <li>Acts or omissions of our auxiliary persons and subcontractors.</li>
+            <li>Simple negligence.</li>
+          </ul>
+          Furthermore, the website is made available “as is,” and we exclude all conditions, liabilities, warranties,
+          representations or other terms that may apply to our website or any content on it, whether express or implied.
+          <br />
+          <br />
+          We also will not be liable to any user for any loss or damage, whether in contract, tort, breach of statutory
+          duty, or otherwise, even if foreseeable, arising under or in connection with:
+          <ul>
+            <li>Use of, or inability to use, our website or</li>
+            <li>Use of or reliance on any content displayed on our website.</li>
+          </ul>
+          We will not be liable for any loss or damage caused by a virus, distributed denial-of-service attack, or other
+          technologically harmful material that May infect your computer equipment, computer programs, data or other
+          proprietary material due to your use of our website or to your downloading of any content on it, or on any
+          website linked to it.
+          <br />
+          <br />
+          Our website may contain third-party content or links to third-party websites or applications for your
+          convenience only. You understand that your use of any third-party website or application is subject to any
+          terms of service and/or privacy notices provided by such third party. We assume no responsibility for
+          third-party content or links to third-party websites or applications to which we link from our website. Such
+          links should not be interpreted as endorsement by us of those linked websites or applications. We will not be
+          liable for any loss or damage that May arise from your use of them.
+          <br />
+          <br />
+          The exclusion of liability under these terms of service shall not apply if the damage is caused willfully or
+          by our gross negligence or unless we should be liable otherwise pursuant to mandatory legal provisions such as
+          product liability. Moreover, the exclusion of liability does not apply to damage from injury to life, body or
+          health (Personal injuries).
+        </Description>
+        <Title>Privacy</Title>
+        <Description>
+          Please see our Privacy Policy to understand how we collect and use your personal data.
+        </Description>
+        <Title>Governing Law and Jurisdiction</Title>
+        <Description>
+          These Terms of Service are governed by and construed in accordance with the substantive laws of Switzerland
+          (without regard to conflicts of laws principles). The application of the United Nations Convention on
+          Contracts for the International Sale of Goods shall be excluded.
+          <br />
+          <br />
+          All disputes arising out of or in connection with these Terms of Service shall be exclusively submitted to the
+          competent courts of the city of Zurich, Switzerland.
+        </Description>
+      </StyledContainer>
+    </Section>
+  );
+};
+
+export default TermsOfService;

--- a/src/pages/staking-hub/landingPage.tsx
+++ b/src/pages/staking-hub/landingPage.tsx
@@ -346,7 +346,7 @@ const faq: FaqData = [
     title: 'What is the HOPR Safe?',
     content: (
       <span>
-        The HOPR Safe is a smart contract wallet built using
+        The HOPR Safe is a smart contract wallet built using{' '}
         <a
           href="https://Safe.global/"
           target="_blank"
@@ -355,7 +355,7 @@ const faq: FaqData = [
           Safe
         </a>
         . It allows you to store assets with complete security and spin up a HOPR node in order to earn tokens as a node
-        runner. To create your own HOPR Safe, follow the instructions
+        runner. To create your own HOPR Safe, follow the instructions{' '}
         <a
           href="/staking/onboarding"
           target="_blank"

--- a/src/pages/staking-hub/landingPage.tsx
+++ b/src/pages/staking-hub/landingPage.tsx
@@ -7,7 +7,6 @@ import ContinueOnboarding from '../../components/Modal/staking-hub/ContinueOnboa
 import { useState } from 'react';
 import { Accordion, AccordionDetails, AccordionSummary, Card } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import TelegramIcon from '@mui/icons-material/Telegram';
 import Footer from '../../future-hopr-lib-components/Layout/footer';
 import StartOnboarding from '../../components/Modal/staking-hub/StartOnboarding';
 
@@ -78,7 +77,6 @@ const FurtherReadingButton = styled(Button)`
   justify-content: space-evenly;
   flex: '0 0 33.333333%';
 `;
-
 
 const SideToSideContainer = styled.div`
   display: flex;
@@ -311,10 +309,17 @@ const faq: FaqData = [
     title: 'How much can I expect to earn running a HOPR node?',
     content: (
       <span>
-        'The amount of $HOPR earned will vary depending on your stake, the number of nodes in the network, your
-        availability and how well-connected you are in the network. It’s expected that the average node will earn an APY
+        The amount of $HOPR earned will vary depending on your stake, the number of nodes in the network, your
+        availability and how well-connected you are in the network. It's expected that the average node will earn an APY
         of 10-15%, but you can find a complete breakdown of the economic model of reward distribution and strategies to
-        increase your share [here.](link to docs)',
+        increase your share{' '}
+        <a
+          href="https://twitter.com/hoprnet/status/1696539901305790534"
+          target="_blank"
+          rel="noreferrer"
+        >
+          here.
+        </a>
       </span>
     ),
   },
@@ -332,7 +337,7 @@ const faq: FaqData = [
   },
   {
     id: 5,
-    title: 'What is HOPR? ',
+    title: 'What is HOPR?',
     content:
       'The HOPR network is an incentivized p2p mixnet where nodes are relay points for transferring data between users. Data is encrypted and mixed in between nodes so only the users at the source and destination of the data can know the source and destination and decrypt the data.',
   },
@@ -341,19 +346,23 @@ const faq: FaqData = [
     title: 'What is the HOPR Safe?',
     content: (
       <span>
-        The HOPR Safe is a smart contract wallet built using 
-        <a 
+        The HOPR Safe is a smart contract wallet built using
+        <a
           href="https://Safe.global/"
-          target='_blank'
-          rel="noopener noreferrer"
-        >Safe</a>. It allows you to
-        store assets with complete security and spin up a HOPR node in order to earn tokens as a node runner. To create
-        your own HOPR Safe, follow the instructions 
-        <a 
-        href="/staking/onboarding"
-        target='_blank'
-        rel="noopener noreferrer"
-        >here.</a>
+          target="_blank"
+          rel="noreferrer"
+        >
+          Safe
+        </a>
+        . It allows you to store assets with complete security and spin up a HOPR node in order to earn tokens as a node
+        runner. To create your own HOPR Safe, follow the instructions
+        <a
+          href="/staking/onboarding"
+          target="_blank"
+          rel="noreferrer"
+        >
+          here.
+        </a>
       </span>
     ),
   },
@@ -408,7 +417,7 @@ const StakingLandingPage = () => {
             onClick={() => set_openWeb3Modal(true)}
             disabled={status.connected}
           >
-            {status.connected ? 'WALLECT CONNECTED' : 'CONNECT WALLET'} 
+            {status.connected ? 'WALLECT CONNECTED' : 'CONNECT WALLET'}
           </StyledButton>
           <BrandsSection>
             <Brand>
@@ -509,7 +518,12 @@ const StakingLandingPage = () => {
             </BlueImageSide>
           </BlueSideToSideContainer>
           <Image src="/assets/create-you-hopr-safe-now.svg" />
-          <BlueSectionButton>Connect Wallet</BlueSectionButton>
+          <BlueSectionButton
+            onClick={() => set_openWeb3Modal(true)}
+            disabled={status.connected}
+          >
+            {status.connected ? 'WALLECT CONNECTED' : 'CONNECT WALLET'}
+          </BlueSectionButton>
         </StyledContainer>
       </Section>
       <Section
@@ -540,18 +554,23 @@ const StakingLandingPage = () => {
               <SideTitle>Hopr safe</SideTitle>
               <SideDescription>
                 The HOPR Safe is a secured smart contract wallet built using{' '}
-                <a 
-                href="https://safe.global/"
-                target='_blank'
-                rel="noopener noreferrer"
-                >Safe (previously called Gnosis Safe).</a> Assets deposited into your HOPR
-                Safe are secured by a customizable multisig, limiting exposure even when your HOPR node's private key
-                gets compromised.
+                <a
+                  href="https://safe.global/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Safe (previously called Gnosis Safe).
+                </a>{' '}
+                Assets deposited into your HOPR Safe are secured by a customizable multisig, limiting exposure even when
+                your HOPR node's private key gets compromised.
                 <br />
                 <a
-                  target='_blank'
-                  rel="noopener noreferrer"
-                >Read more LINK NEEEEEDED!</a>
+                  href="https://docs.hoprnet.org/developers/safestaking-by-hopr#what-is-safestaking"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Read more
+                </a>
               </SideDescription>
             </TextSide>
           </SideToSideContainer>
@@ -563,11 +582,13 @@ const StakingLandingPage = () => {
                 service. Your node will automatically request tokens from your Safe to fund these channels. Run a
                 well-connected node to maximize your earnings.
                 <br />
-                <a 
-                  href="https://docs.hoprnet.org/core/tickets-and-payment-channels" 
-                  target='_blank'
-                  rel="noopener noreferrer"
-                >Read more</a>
+                <a
+                  href="https://docs.hoprnet.org/core/tickets-and-payment-channels"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Read more
+                </a>
               </SideDescription>
             </TextSide>
             <ImageSide>
@@ -606,19 +627,51 @@ const StakingLandingPage = () => {
         <BigTitle>Further Reading</BigTitle>
         <br />
         <FurtherReadingButtonsSection>
-          <FurtherReadingButton href="" disabled>
+          <FurtherReadingButton
+            href="https://docs.hoprnet.org/"
+            target="_blank"
+            rel="noreferrer"
+          >
             <img src="/assets/docs-icon.svg" />
             View Docs
           </FurtherReadingButton>
-          <FurtherReadingButton disabled>Why use Safe?</FurtherReadingButton>
-          <FurtherReadingButton disabled>How to install</FurtherReadingButton>
+          <FurtherReadingButton
+            href="https://docs.hoprnet.org/developers/safestaking-by-hopr#why-use-safe"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Why use Safe?
+          </FurtherReadingButton>
+          <FurtherReadingButton
+            href="https://docs.hoprnet.org/node/start-here"
+            target="_blank"
+            rel="noreferrer"
+          >
+            How to install
+          </FurtherReadingButton>
           <br />
-          <FurtherReadingButton disabled>Buy Tokens</FurtherReadingButton>
-          <FurtherReadingButton disabled>How it works</FurtherReadingButton>
+          <FurtherReadingButton
+            href="https://docs.hoprnet.org/staking/how-to-get-hopr"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Buy Tokens
+          </FurtherReadingButton>
+          <FurtherReadingButton
+            href="https://docs.hoprnet.org/developers/safestaking-by-hopr#architecture"
+            target="_blank"
+            rel="noreferrer"
+          >
+            How it works
+          </FurtherReadingButton>
         </FurtherReadingButtonsSection>
         <MediumText>Still got questions? Contact us here.</MediumText>
         <br />
-        <FurtherReadingButton disabled>
+        <FurtherReadingButton
+          href="https://t.me/hoprnet"
+          target="_blank"
+          rel="noreferrer"
+        >
           <img src="/assets/telegram-icon.svg" />
           Telegram
         </FurtherReadingButton>

--- a/src/pages/staking-hub/landingPage.tsx
+++ b/src/pages/staking-hub/landingPage.tsx
@@ -423,19 +423,37 @@ const StakingLandingPage = () => {
             <Brand>
               <BrandText>DEVELOPED USING</BrandText>
               <BrandImage>
-                <img src="/assets/safe-icon2.svg" />
+                <a
+                  href="https://safe.global/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <img src="/assets/safe-icon2.svg" />
+                </a>
               </BrandImage>
             </Brand>
             <Brand>
               <BrandText>RUNNING ON</BrandText>
               <BrandImage>
-                <img src="/assets/gnosis-chain-logo.svg" />
+                <a
+                  href="https://www.gnosis.io/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <img src="/assets/gnosis-chain-logo.svg" />
+                </a>
               </BrandImage>
             </Brand>
             <Brand>
               <BrandText>POWERED BY</BrandText>
               <BrandImage>
-                <img src="/assets/the-graph-logo.svg" />
+                <a
+                  href="https://thegraph.com/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <img src="/assets/the-graph-logo.svg" />
+                </a>
               </BrandImage>
             </Brand>
           </BrandsSection>
@@ -454,7 +472,14 @@ const StakingLandingPage = () => {
               </SideTitle>
               <SideDescription>
                 You earn $HOPR for every packet of data you relay. This is done in a secure and decentralized fashion
-                through our proof-of-relay mechanism.
+                through our{' '}
+                <a
+                  href="https://docs.hoprnet.org/core/proof-of-relay"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  proof-of-relay mechanism.
+                </a>
               </SideDescription>
             </TextSide>
           </SideToSideContainer>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,11 @@
 import { useEffect } from 'react';
-import { createBrowserRouter, RouteObject, useSearchParams, Navigate, useLocation } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  RouteObject,
+  useSearchParams,
+  Navigate,
+  useLocation
+} from 'react-router-dom'
 import { environment } from '../config';
 
 // Store
@@ -30,7 +36,7 @@ import NodeAdded from './pages/staking-hub/dashboard/node';
 import SafeActions from './pages/staking-hub/dashboard/transactions';
 import NoNodeAdded from './pages/staking-hub/dashboard/noNodeAdded';
 import Onboarding from './pages/staking-hub/onboarding';
-import Dashboard from './pages/staking-hub/dashboard'
+import Dashboard from './pages/staking-hub/dashboard';
 
 // Layout
 import Layout from './future-hopr-lib-components/Layout';
@@ -63,6 +69,8 @@ import OutgoingChannelsIcon from './future-hopr-lib-components/Icons/OutgoingCha
 import TrainIcon from './future-hopr-lib-components/Icons/TrainIcon';
 import SpaceDashboardIcon from '@mui/icons-material/SpaceDashboard';
 import { stakingHubActions } from './store/slices/stakingHub';
+import TermsOfService from './pages/TermsOfService';
+import PrivacyNotice from './pages/PrivacyNotice';
 
 export type ApplicationMapType = {
   groupName: string;
@@ -217,12 +225,11 @@ export const applicationMapStakingHub: ApplicationMapType = [
         name: 'Docs',
         path: 'https://docs.hoprnet.org/',
         icon: <DescriptionOutlinedIcon />,
-       // element: <span/>,
+        // element: <span/>,
       },
-    ]
-  }
+    ],
+  },
 ];
-
 
 export const applicationMapDevWeb3: ApplicationMapType = [
   {
@@ -283,9 +290,9 @@ const LayoutEnhanced = () => {
 
   useEffect(() => {
     if (environment === 'web3') {
-      document.title = "HOPR | Staking Hub"
+      document.title = 'HOPR | Staking Hub';
     } else if (environment === 'node') {
-      document.title = "HOPR | Node Admin"
+      document.title = 'HOPR | Node Admin';
     }
   }, []);
 
@@ -343,16 +350,14 @@ const LayoutEnhanced = () => {
 
   useEffect(() => {
     if (!HOPRdNodeAddressForOnboarding) return;
-    dispatch(
-      stakingHubActions.setNodeAddressProvidedByMagicLink(HOPRdNodeAddressForOnboarding),
-    );
+    dispatch(stakingHubActions.setNodeAddressProvidedByMagicLink(HOPRdNodeAddressForOnboarding));
   }, [HOPRdNodeAddressForOnboarding]);
 
-  const showInfoBar = ()=> {
-    if(environment === 'web3' && location.pathname === "/") return false;
-    if(isConnected || nodeConnected) return true;
+  const showInfoBar = () => {
+    if (environment === 'web3' && location.pathname === '/') return false;
+    if (isConnected || nodeConnected) return true;
     return false;
-  }
+  };
 
   return (
     <Layout
@@ -368,13 +373,13 @@ const LayoutEnhanced = () => {
       drawerType={environment === 'web3' ? 'blue' : undefined}
       itemsNavbarRight={
         <>
-          {(environment === 'dev' || environment === 'node') && <NotificationBar />} 
+          {(environment === 'dev' || environment === 'node') && <NotificationBar />}
           {(environment === 'dev' || environment === 'web3') && <ConnectSafe />}
           {(environment === 'dev' || environment === 'web3') && <ConnectWeb3 inTheAppBar />}
           {(environment === 'dev' || environment === 'node') && <ConnectNode />}
         </>
       }
-      drawerRight={showInfoBar()&& <InfoBar />}
+      drawerRight={showInfoBar() && <InfoBar />}
     />
   );
 };
@@ -387,7 +392,17 @@ var routes = [
   },
   {
     path: '*',
-    element: <Navigate to="/" replace />,
+    element: (
+      <Navigate
+        to="/"
+        replace
+      />
+    ),
+    children: [] as RouteObject[],
+  },
+  {
+    path: '/tos',
+    element: <TermsOfService />,
     children: [] as RouteObject[],
   },
 ];
@@ -412,6 +427,15 @@ applicationMap.map((groups) => {
       });
     }
   });
+});
+
+routes[0].children.push({
+  path: '/tos',
+  element: <TermsOfService />,
+});
+routes[0].children.push({
+  path: '/privacy-notice',
+  element: <PrivacyNotice />,
 });
 
 const router = createBrowserRouter(routes);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -400,11 +400,6 @@ var routes = [
     ),
     children: [] as RouteObject[],
   },
-  {
-    path: '/tos',
-    element: <TermsOfService />,
-    children: [] as RouteObject[],
-  },
 ];
 
 applicationMap.map((groups) => {


### PR DESCRIPTION
Closes #293 #313 #314 

### Overview

In this PR multiple issues have been addressed. Since they were mostly related, they were from fixing another, solved.

- The FAQ copy was updated and so were the FAQ urls.
- The links on the FAQ were added and so were the staking landing page. 
- To completely update the links from the landing page we had to make 2 new pages called `TermsOfService` and `PrivacyNotice` so that the footer has the links updated.

### Notes
- Managing wxHopr allowance link is missing since there is no page yet. (`/staking/dashboard#node` 4th faq)
- noNodeAdded page has `Add node to your safe` link but couldn't find page being used.
- `STORE FUNDS WITH <COMPLETE SECURITY>` in landing page missing (not in figma)

- Some links redirect to the page as a new tab even when it's inside the same hopr admin (haven't found a way to pass node login params through it)
  - This is the case for links in FAQ that redirect to onboarding and the links in the footer for ToS and Privacy Policy