### PR TITLE
Update open channel modal placeholder

### DIFF
--- a/src/components/Modal/node/OpenOrFundChannelModal.tsx
+++ b/src/components/Modal/node/OpenOrFundChannelModal.tsx
@@ -18,7 +18,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import HubIcon from '@mui/icons-material/Hub';
 
 type OpenOrFundChannelModalProps = {
-  peerId?: string;
+  peerAddress?: string;
   modalBtnText?: string;
   actionBtnText?: string;
   title?: string;
@@ -36,7 +36,7 @@ export const OpenOrFundChannelModal = ({
   const loginData = useAppSelector((store) => store.auth.loginData);
   const [openChannelModal, set_openChannelModal] = useState(false);
   const [amount, set_amount] = useState('');
-  const [peerId, set_peerId] = useState(props.peerId ? props.peerId : '');
+  const [peerAddress, set_peerAddress] = useState(props.peerAddress ? props.peerAddress : '');
 
   const handleOpenChannelDialog = () => {
     set_openChannelModal(true);
@@ -45,23 +45,23 @@ export const OpenOrFundChannelModal = ({
   const handleCloseModal = () => {
     set_openChannelModal(false);
     set_amount('');
-    set_peerId(props.peerId ? props.peerId : '');
+    set_peerAddress(props.peerAddress ? props.peerAddress : '');
   };
 
   const handleAction = async () => {
-    const handleOpenChannel = async (weiValue: string, peerId: string) => {
+    const handleOpenChannel = async (weiValue: string, peerAddress: string) => {
       await dispatch(
         actionsAsync.openChannelThunk({
           apiEndpoint: loginData.apiEndpoint!,
           apiToken: loginData.apiToken!,
           amount: weiValue,
-          peerAddress: peerId,
+          peerAddress: peerAddress,
           timeout: 60e3,
         }),
       )
         .unwrap()
         .then(() => {
-          const msg = `Channel to ${peerId} is ${type === 'open' ? 'opened' : 'funded'}`;
+          const msg = `Channel to ${peerAddress} is ${type === 'open' ? 'opened' : 'funded'}`;
           sendNotification({
             notificationPayload: {
               source: 'node',
@@ -74,7 +74,7 @@ export const OpenOrFundChannelModal = ({
           });
         })
         .catch((e) => {
-          let errMsg = `Channel to ${peerId} failed to be ${type === 'open' ? 'opened' : 'funded'}`;
+          let errMsg = `Channel to ${peerAddress} failed to be ${type === 'open' ? 'opened' : 'funded'}`;
           if (e.status) errMsg = errMsg + `\n${e.status}`;
           sendNotification({
             notificationPayload: {
@@ -92,7 +92,7 @@ export const OpenOrFundChannelModal = ({
     handleCloseModal();
     const parsedOutgoing = parseFloat(amount ?? '0') >= 0 ? amount ?? '0' : '0';
     const weiValue = ethers.utils.parseEther(parsedOutgoing).toString();
-    await handleOpenChannel(weiValue, peerId);
+    await handleOpenChannel(weiValue, peerAddress);
     dispatch(
       actionsAsync.getChannelsThunk({
         apiEndpoint: loginData.apiEndpoint!,
@@ -135,10 +135,10 @@ export const OpenOrFundChannelModal = ({
         </TopBar>
         <SDialogContent>
           <TextField
-            label="Peer ID"
-            value={peerId}
-            placeholder="16Uiu2HA..."
-            onChange={(e) => set_peerId(e.target.value)}
+            label="Peer Address"
+            value={peerAddress}
+            placeholder="0x4f5a...1728"
+            onChange={(e) => set_peerAddress(e.target.value)}
             sx={{ mt: '6px' }}
           />
           <TextField
@@ -154,7 +154,7 @@ export const OpenOrFundChannelModal = ({
         <DialogActions>
           <Button
             onClick={handleAction}
-            disabled={!amount || parseFloat(amount) <= 0 || !peerId}
+            disabled={!amount || parseFloat(amount) <= 0 || !peerAddress}
             style={{
               marginRight: '16px',
               marginBottom: '6px',

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -42,7 +42,7 @@ function AliasesPage() {
         actionsAsync.getAliasesThunk({
           apiEndpoint: loginData.apiEndpoint,
           apiToken: loginData.apiToken,
-        }),
+        })
       );
     }
   }, [loginData]);
@@ -53,7 +53,7 @@ function AliasesPage() {
         actionsAsync.getAliasesThunk({
           apiEndpoint: loginData.apiEndpoint,
           apiToken: loginData.apiToken,
-        }),
+        })
       );
     }
   };
@@ -65,7 +65,7 @@ function AliasesPage() {
           alias: alias,
           peerId: aliases[alias],
         })),
-        'aliases.csv',
+        'aliases.csv'
       );
     }
   };
@@ -80,7 +80,7 @@ function AliasesPage() {
             peerId: String(data.peerId),
             apiEndpoint: loginData.apiEndpoint,
             apiToken: loginData.apiToken,
-          }),
+          })
         )
           .unwrap()
           .then(() => {
@@ -110,7 +110,7 @@ function AliasesPage() {
       actions: (
         <>
           <OpenOrFundChannelModal
-            peerId={peerId}
+            // peerAddress={peerId} // FIXME: peerId should be peerAddress here
             type={'open'}
           />
           <SendMessageModal peerId={peerId} />
@@ -217,7 +217,7 @@ function DeleteAliasButton({
               alias,
               apiEndpoint: loginData.apiEndpoint,
               apiToken: loginData.apiToken,
-            }),
+            })
           )
             .unwrap()
             .then(() => {
@@ -244,10 +244,7 @@ function CreateAliasForm() {
   });
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const {
-      name,
-      value,
-    } = event.target;
+    const { name, value } = event.target;
     set_form({
       ...form,
       [name]: value,
@@ -280,7 +277,7 @@ function CreateAliasForm() {
                 peerId: form.peerId,
                 apiEndpoint: loginData.apiEndpoint,
                 apiToken: loginData.apiToken,
-              }),
+              })
             )
               .unwrap()
               .then(() => {

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -71,13 +71,13 @@ function ChannelsPage() {
       actionsAsync.getChannelsThunk({
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken!,
-      }),
+      })
     );
     dispatch(
       actionsAsync.getAliasesThunk({
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken!,
-      }),
+      })
     );
   };
 
@@ -101,7 +101,7 @@ function ChannelsPage() {
           status: channel.status,
           dedicatedFunds: channel.balance,
         })),
-        `${tabLabel}-channels.csv`,
+        `${tabLabel}-channels.csv`
       );
     }
   };
@@ -149,7 +149,7 @@ function ChannelsPage() {
         <>
           <PingModal peerId={channel.peerId} />
           <OpenOrFundChannelModal
-            peerId={channel.peerId}
+            // peerAddress={channel.peerId} // FIXME: peerId should be peerAddress here
             title="Open outgoing channel"
             type={'open'}
           />

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -88,13 +88,13 @@ function ChannelsPage() {
       actionsAsync.getChannelsThunk({
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken!,
-      }),
+      })
     );
     dispatch(
       actionsAsync.getAliasesThunk({
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken!,
-      }),
+      })
     );
   };
 
@@ -118,7 +118,7 @@ function ChannelsPage() {
           status: channel.status,
           dedicatedFunds: channel.balance,
         })),
-        `${tabLabel}-channels.csv`,
+        `${tabLabel}-channels.csv`
       );
     }
   };
@@ -138,7 +138,7 @@ function ChannelsPage() {
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken!,
         channelId: channelId,
-      }),
+      })
     )
       .unwrap()
       .then(() => {
@@ -236,7 +236,7 @@ function ChannelsPage() {
         <>
           <PingModal peerId={channel.peerId} />
           <OpenOrFundChannelModal
-            peerId={channel.peerId}
+            // peerAddress={channel.peerId} //FIXME: peerId should be peerAddress here
             title="Fund outgoing channel"
             modalBtnText="Fund outgoing channel"
             actionBtnText="Fund outgoing channel"

--- a/src/pages/node/peers.tsx
+++ b/src/pages/node/peers.tsx
@@ -144,7 +144,7 @@ function PeersPage() {
             peerId={peer.peerId}
           />
           <OpenOrFundChannelModal
-            peerId={peer.peerId}
+            // peerAddress={peer.peerAddress} // FIXME: peer doesnt have peerAddress property yet
             type={'open'}
           />
           <SendMessageModal peerId={peer.peerId} />


### PR DESCRIPTION
Closes #343 

## Overview

This PR corrects the modal placeholder and text to display 'peerAddress' instead of peerId.

### Note
Since the peer redux state does not have `peerAddress` yet, we left the field empty until this state becomes available