### PR TITLE
Remove wxhopr node admin

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-export const environment: 'dev' | 'node' | 'web3' = 'node';
+export const environment: 'dev' | 'node' | 'web3' = 'dev';
 
 // Smart Contracts
 export const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e';

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-export const environment: 'dev' | 'node' | 'web3' = 'dev';
+export const environment: 'dev' | 'node' | 'web3' = 'node';
 
 // Smart Contracts
 export const HOPR_CHANNELS_SMART_CONTRACT_ADDRESS = '0xfabee463f31e39ec8952bbfb4490c41103bf573e';

--- a/src/components/InfoBar/details.tsx
+++ b/src/components/InfoBar/details.tsx
@@ -221,7 +221,6 @@ export default function Details(props: Props) {
         <DataTitle>Node</DataTitle>
         <Data className="nodeOnly">
           <p>{info?.connectivityStatus}</p>
-          <p>{balances.hopr?.formatted ?? '-'}</p>
           <p>{balances.native?.formatted ?? '-'}</p>
           <p>{truncateBalanceto5charsWhenNoDecimals(peers?.announced?.length) || '-'}</p>
           <p className="double">{truncateBalanceto5charsWhenNoDecimals(channels?.outgoing?.length) || '-'}</p>

--- a/src/components/InfoBar/details.tsx
+++ b/src/components/InfoBar/details.tsx
@@ -1,4 +1,3 @@
-import { HOPR_TOKEN_USED } from '../../../config';
 import { useAppSelector } from '../../store';
 import styled from '@emotion/styled';
 
@@ -199,15 +198,6 @@ export default function Details(props: Props) {
         <IconAndText>
           <IconContainer>
             <Icon
-              src="/assets/xHoprIcon.svg"
-              alt="xHOPR Icon"
-            />
-          </IconContainer>
-          <Text>{HOPR_TOKEN_USED}</Text>
-        </IconAndText>
-        <IconAndText>
-          <IconContainer>
-            <Icon
               src="/assets/xDaiIcon.svg"
               alt="xDai Icon"
             />
@@ -220,11 +210,11 @@ export default function Details(props: Props) {
         </IconAndText>
         <IconAndText>
           <IconContainer></IconContainer>
-          <Text>Outgoing Chanels</Text>
+          <Text>Outgoing Channels</Text>
         </IconAndText>
         <IconAndText>
           <IconContainer></IconContainer>
-          <Text>Incoming Chanels</Text>
+          <Text>Incoming Channels</Text>
         </IconAndText>
       </TitleColumn>
       <DataColumn>

--- a/src/pages/node/info.tsx
+++ b/src/pages/node/info.tsx
@@ -11,7 +11,6 @@ import { TableExtended } from '../../future-hopr-lib-components/Table/columed-da
 import { SubpageTitle } from '../../components/SubpageTitle';
 import Tooltip from '../../future-hopr-lib-components/Tooltip/tooltip-fixed-width';
 import WithdrawModal from '../../components/Modal/node/WithdrawModal';
-import { HOPR_TOKEN_USED } from '../../../config';
 
 function InfoPage() {
   const dispatch = useAppDispatch();
@@ -258,19 +257,6 @@ function InfoPage() {
                 </Tooltip>
               </th>
               <td>{balances.native?.formatted} xDai</td>
-            </tr>
-            <tr>
-              <th>
-                <Tooltip
-                  title={`The amount of ${HOPR_TOKEN_USED} tokens stored on your node`}
-                  notWide
-                >
-                  <span>Hopr</span>
-                </Tooltip>
-              </th>
-              <td>
-                {balances.hopr?.formatted} {HOPR_TOKEN_USED}
-              </td>
             </tr>
           </tbody>
         </TableExtended>


### PR DESCRIPTION
closes #334 

### ui
![CleanShot 2023-09-05 at 16 31 28](https://github.com/hoprnet/hopr-admin/assets/22416585/121e35a4-a285-4b14-86c3-2d53a29d6ef9)

- removed wxhopr from the infobar but it can still be seen on the info page. 