### PR TITLE
Add AliasByPeerAddress

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.0",
-    "@hoprnet/hopr-sdk": "^2.0.0-beta.7",
+    "@hoprnet/hopr-sdk": "^2.0.0-beta.9",
     "@metamask/jazzicon": "^2.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -79,7 +79,7 @@ export const SendMessageModal = ({ peerId }: SendMessageModalProps) => {
       apiToken: loginData.apiToken,
       apiEndpoint: loginData.apiEndpoint,
       body: message,
-      peerAddress: validatedReceiver,
+      peerId: validatedReceiver,
       tag: 1,
     };
     if (numberOfHops !== '') {

--- a/src/hooks/useWatcher/index.ts
+++ b/src/hooks/useWatcher/index.ts
@@ -61,6 +61,8 @@ export const useWatcher = ({ intervalDuration = 15000 }: { intervalDuration?: nu
         minimumNodeBalances: {
           hopr: '0',
           native: parseEther('0.003').toString(),
+          safeHopr: '0',
+          safeNative: '0',
         },
         previousState: prevNodeBalances,
         updatePreviousData: (newNodeBalances) => {

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -13,7 +13,6 @@ import IconButton from '../../future-hopr-lib-components/Button/IconButton';
 import TablePro from '../../future-hopr-lib-components/Table/table-pro';
 
 // Modals
-import { PingModal } from '../../components/Modal/node/PingModal';
 import { OpenOrFundChannelModal } from '../../components/Modal/node/OpenOrFundChannelModal';
 
 // Mui
@@ -23,7 +22,6 @@ function ChannelsPage() {
   const dispatch = useAppDispatch();
   const channels = useAppSelector((store) => store.node.channels.data);
   const channelsFetching = useAppSelector((store) => store.node.channels.isFetching);
-  const aliases = useAppSelector((store) => store.node.aliases.data);
   const loginData = useAppSelector((store) => store.auth.loginData);
 
   const tabLabel = 'incoming';
@@ -67,39 +65,39 @@ function ChannelsPage() {
     );
   };
 
-  const getAliasByPeerId = (peerId: string): string => {
-    if (aliases) {
-      for (const [alias, id] of Object.entries(aliases)) {
-        if (id === peerId) {
-          return alias;
-        }
-      }
-    }
-    return peerId; // Return the peerId if alias not found for the given peerId
-  };
+  // const getAliasByPeerId = (peerId: string): string => {
+  //   if (aliases) {
+  //     for (const [alias, id] of Object.entries(aliases)) {
+  //       if (id === peerId) {
+  //         return alias;
+  //       }
+  //     }
+  //   }
+  //   return peerId; // Return the peerId if alias not found for the given peerId
+  // };
 
   const handleExport = () => {
     if (channelsData) {
       exportToCsv(
         Object.entries(channelsData).map(([, channel]) => ({
           channelId: channel.id,
-          peerId: channel.peerId,
+          peerAddress: channel.peerAddress,
           status: channel.status,
           dedicatedFunds: channel.balance,
         })),
-        `${tabLabel}-channels.csv`
+        `${tabLabel}-channels.csv`,
       );
     }
   };
 
-  const headerIncomming = [
+  const headerIncoming = [
     {
       key: 'key',
       name: '#',
     },
     {
-      key: 'peerId',
-      name: 'Peer Id',
+      key: 'peerAddress',
+      name: 'Peer Address',
       search: true,
       maxWidth: '568px',
       tooltip: true,
@@ -125,18 +123,19 @@ function ChannelsPage() {
     },
   ];
 
-  const parsedTableDataIncomming = Object.entries(channels?.incoming ?? []).map(([, channel], key) => {
+  const parsedTableDataIncoming = Object.entries(channels?.incoming ?? []).map(([, channel], key) => {
     return {
       id: channel.id,
       key: key.toString(),
-      peerId: getAliasByPeerId(channel.peerId),
+      peerAddress: channel.peerAddress,
       status: channel.status,
       funds: `${utils.formatEther(channel.balance)} ${HOPR_TOKEN_USED}`,
       actions: (
         <>
-          <PingModal peerId={channel.peerId} />
+          {/* we need a peer id from channels to make this work
+          <PingModal /> */}
           <OpenOrFundChannelModal
-            // peerAddress={channel.peerId} // FIXME: peerId should be peerAddress here
+            peerAddress={channel.peerAddress}
             title="Open outgoing channel"
             type={'open'}
           />
@@ -174,10 +173,10 @@ function ChannelsPage() {
         }
       />
       <TablePro
-        data={parsedTableDataIncomming}
-        header={headerIncomming}
+        data={parsedTableDataIncoming}
+        header={headerIncoming}
         search
-        loading={parsedTableDataIncomming.length === 0 && channelsFetching}
+        loading={parsedTableDataIncoming.length === 0 && channelsFetching}
       />
     </Section>
   );

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -22,6 +22,8 @@ function ChannelsPage() {
   const dispatch = useAppDispatch();
   const channels = useAppSelector((store) => store.node.channels.data);
   const channelsFetching = useAppSelector((store) => store.node.channels.isFetching);
+  const aliases = useAppSelector((store) => store.node.aliases.data)
+  const peers = useAppSelector((store) => store.node.peers.data)
   const loginData = useAppSelector((store) => store.auth.loginData);
 
   const tabLabel = 'incoming';
@@ -30,7 +32,7 @@ function ChannelsPage() {
   const [queryParams, set_queryParams] = useState('');
 
   const navigate = useNavigate();
-        
+
   const handleHash = () => {
     navigate(`?${queryParams}#incoming`, { replace: true });
   };
@@ -63,18 +65,33 @@ function ChannelsPage() {
         apiToken: loginData.apiToken!,
       })
     );
+    dispatch(
+      actionsAsync.getPeersThunk({
+        apiEndpoint: loginData.apiEndpoint!,
+        apiToken: loginData.apiToken!,
+      })
+    )
   };
 
-  // const getAliasByPeerId = (peerId: string): string => {
-  //   if (aliases) {
-  //     for (const [alias, id] of Object.entries(aliases)) {
-  //       if (id === peerId) {
-  //         return alias;
-  //       }
-  //     }
-  //   }
-  //   return peerId; // Return the peerId if alias not found for the given peerId
-  // };
+  const getAliasByPeerAddress = (peerAddress: string): string => {
+
+    const peerId = peers?.announced.find(peer => peer.peerAddress === peerAddress)?.peerId;
+
+    if (!peerId) {
+      return peerAddress;
+    }
+
+    if (aliases) {
+      for (const [alias, id] of Object.entries(aliases)) {
+        console.log(`ID: ${id}: ${alias}`)
+        if (id === peerId) {
+          return alias;
+        }
+      }
+    }
+
+    return peerAddress
+  }
 
   const handleExport = () => {
     if (channelsData) {
@@ -127,7 +144,7 @@ function ChannelsPage() {
     return {
       id: channel.id,
       key: key.toString(),
-      peerAddress: channel.peerAddress,
+      peerAddress: getAliasByPeerAddress(channel.peerAddress),
       status: channel.status,
       funds: `${utils.formatEther(channel.balance)} ${HOPR_TOKEN_USED}`,
       actions: (

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -15,7 +15,6 @@ import CloseChannelIcon from '../../future-hopr-lib-components/Icons/CloseChanne
 import TablePro from '../../future-hopr-lib-components/Table/table-pro';
 
 // Modals
-import { PingModal } from '../../components/Modal/node/PingModal';
 import { OpenOrFundChannelModal } from '../../components/Modal/node/OpenOrFundChannelModal';
 import { OpenMultipleChannelsModal } from '../../components/Modal/node/OpenMultipleChannelsModal';
 
@@ -26,7 +25,6 @@ function ChannelsPage() {
   const dispatch = useAppDispatch();
   const channels = useAppSelector((store) => store.node.channels.data);
   const channelsFetching = useAppSelector((store) => store.node.channels.isFetching);
-  const aliases = useAppSelector((store) => store.node.aliases.data);
   const loginData = useAppSelector((store) => store.auth.loginData);
   const [closingStates, set_closingStates] = useState<
     Record<
@@ -82,23 +80,24 @@ function ChannelsPage() {
     );
   };
 
-  const getAliasByPeerId = (peerId: string): string => {
-    if (aliases) {
-      for (const [alias, id] of Object.entries(aliases)) {
-        if (id === peerId) {
-          return alias;
-        }
-      }
-    }
-    return peerId; // Return the peerId if alias not found for the given peerId
-  };
+  // TODO: update to getAliasByPeerAddress
+  // const getAliasByPeerId = (peerId: string): string => {
+  //   if (aliases) {
+  //     for (const [alias, id] of Object.entries(aliases)) {
+  //       if (id === peerId) {
+  //         return alias;
+  //       }
+  //     }
+  //   }
+  //   return peerId; // Return the peerId if alias not found for the given peerId
+  // };
 
   const handleExport = () => {
     if (channelsData) {
       exportToCsv(
         Object.entries(channelsData).map(([, channel]) => ({
           channelId: channel.id,
-          peerId: channel.peerId,
+          peerAddress: channel.peerAddress,
           status: channel.status,
           dedicatedFunds: channel.balance,
         })),
@@ -182,8 +181,8 @@ function ChannelsPage() {
       name: '#',
     },
     {
-      key: 'peerId',
-      name: 'Peer Id',
+      key: 'peerAddress',
+      name: 'Peer Address',
       search: true,
       tooltip: true,
       maxWidth: '168px',
@@ -214,14 +213,15 @@ function ChannelsPage() {
     return {
       id: channel.id,
       key: key.toString(),
-      peerId: getAliasByPeerId(channel.peerId),
+      peerAddress: channel.peerAddress,
       status: channel.status,
       funds: `${utils.formatEther(channel.balance)} ${HOPR_TOKEN_USED}`,
       actions: (
         <>
-          <PingModal peerId={channel.peerId} />
+          {/* we need a way to get peer id to ping from channel */}
+          {/* <PingModal peerId={channel.peerId} /> */}
           <OpenOrFundChannelModal
-            // peerAddress={channel.peerId} //FIXME: peerId should be peerAddress here
+            peerAddress={channel.peerAddress}
             title="Fund outgoing channel"
             modalBtnText={
               <span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,10 +887,10 @@
   resolved "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.8.tgz"
   integrity sha512-XxPltXs5R31D6UZeLIV1td3wTXU3jzd3f2DLsXI8tytMGBkIsGcc9sIyiupRtA8y73HAhuSCeweOoBqf6DbWCA==
 
-"@hoprnet/hopr-sdk@^2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-2.0.0-beta.7.tgz#e85d01faac0930fbbf103561f65ba1b6df5a63c1"
-  integrity sha512-oJi0015H3VJSgYwaeWfD9zWtqUrsbz8Nol7vuWZFyoRQr3er5QthtQ9utdMo4ce0CBKQzd50j5ngYpYMnLyQTA==
+"@hoprnet/hopr-sdk@^2.0.0-beta.9":
+  version "2.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-2.0.0-beta.9.tgz#e93d631da2d0d8bfd1f2516aa883b0da201b7eca"
+  integrity sha512-tiWTpRG1IFQ2XbmtjJ6hiP6Ivu8nlDMBvUUZF/riSuyu0PPfky3pxyeVL6a4epc+7DMQ2M79hMKFpNk0wBAgiQ==
   dependencies:
     cross-fetch "^3.1.5"
     debug "^4.3.4"


### PR DESCRIPTION
Related #358

### Overview
In the last changes to the sdk we were able to get peerAddress and peerId when querying the peers that are announced on the network. With this new addition we can bring back the functionality of showing the alias of the node that has a channel open from or to us.