### PR TITLE
Add initial #staking hash if no hash is provided

### DIFF
--- a/src/pages/staking-hub/dashboard/index.tsx
+++ b/src/pages/staking-hub/dashboard/index.tsx
@@ -30,17 +30,18 @@ export const DASHBOARD = {
 } as { [key: string]: number};
 
 const getTabIndexFromUrl = () => {
-  const currentHash = window.location.hash.replace('#', '');
-  console.log(currentHash)
-  switch(currentHash){
+  let currentHash = window.location.hash.replace('#', '');
+  if (currentHash == "") currentHash = "staking";
+  switch (currentHash) {
     case 'node':
       return DASHBOARD.node;
     case 'safe':
       return DASHBOARD.safe;
     case 'transactions':
       return DASHBOARD.transactions;
-    default: 
-      return DASHBOARD.staking;  
+    default:
+      window.location.hash = `#${currentHash}`;
+      return DASHBOARD.staking;
   }
 };
 


### PR DESCRIPTION
Fixes #353 

### Overview
When a client enters the dashboard, the initial screen that will appear will be the staking screen, although this works as intended, the FAQ component doesn't show because the `#staking` in the url is not present. This pull request adds said string to the url if the dashboard url doesn't have any `#` already.