### PR TITLE
Move wxHopr Allowance to staking screen and rename

### DIFF
--- a/src/pages/staking-hub/dashboard/node.tsx
+++ b/src/pages/staking-hub/dashboard/node.tsx
@@ -29,7 +29,7 @@ const Content = styled.section`
     grid-row: 1/3;
   }
 
-  & #remaining-wxhopr-allowance {
+  & #node-balance {
     grid-column: 3/4;
   }
 
@@ -42,10 +42,6 @@ const Content = styled.section`
   }
 
   & #redeemed-tickets {
-    grid-column: 4/5;
-  }
-
-  & #xdai {
     grid-column: 3/4;
   }
 `;
@@ -95,7 +91,7 @@ const ButtonGroup = styled.div`
   gap: 0.5rem;
 `;
 
-const StyledChip = styled(Chip)<{ color: string }>`
+const StyledChip = styled(Chip) <{ color: string }>`
   align-self: flex-start;
   background-color: ${(props) => props.color === 'error' && '#ffcbcb'};
   background-color: ${(props) => props.color === 'success' && '#cbffd0'};
@@ -257,90 +253,84 @@ const NodeAdded = () => {
   const wxHoprAllowance = useAppSelector((store) => store.stakingHub.safeInfo.data.allowance.wxHoprAllowance);
 
   return (
-        <Content>
-          <GrayCard id="node-graphic">
-            <Graphic>
-              <NodeGraphic>
-                <img
-                  src="/assets/node-graphic.svg"
-                  alt="Node Graphic"
-                />
-              </NodeGraphic>
-              <NodeInfo>
-                <NodeInfoRow>
-                  <p>Node Address</p>
-                  {nodeHoprAddress ? (
-                    <>
-                      <p>{truncateHOPRPeerId(nodeHoprAddress)}</p>
-                      <SquaredIconButton
-                        onClick={() => nodeHoprAddress && navigator.clipboard.writeText(nodeHoprAddress)}
-                      >
-                        <CopyIcon />
-                      </SquaredIconButton>
-                      <Link to={`https://gnosisscan.io/address/${nodeNativeAddress}`}>
-                        <SquaredIconButton>
-                          <LaunchIcon />
-                        </SquaredIconButton>
-                      </Link>
-                    </>
-                  ) : (
-                    <p>-</p>
-                  )}
-                </NodeInfoRow>
-                <NodeInfoRow>
-                  <p>Last seen</p>
-                  <p>- mins</p>
-                </NodeInfoRow>
-                <NodeInfoRow>
-                  <p>Ping</p>
-                  <p>-</p>
-                </NodeInfoRow>
-                <NodeInfoRow>
-                  <p>24h Avail.</p>
-                  <p>-%</p>
-                </NodeInfoRow>
-                <NodeInfoRow>
-                  <p>Availability</p>
-                  <p>-%</p>
-                </NodeInfoRow>
-                <NodeInfoRow>
-                  <p id="actions">Actions</p>
-                  <StyledIconButton
-                    onClick={() => {} /*navigate(`/node/configuration?${queryParams}`)*/}
-                    disabled
+    <Content>
+      <GrayCard id="node-graphic">
+        <Graphic>
+          <NodeGraphic>
+            <img
+              src="/assets/node-graphic.svg"
+              alt="Node Graphic"
+            />
+          </NodeGraphic>
+          <NodeInfo>
+            <NodeInfoRow>
+              <p>Node Address</p>
+              {nodeHoprAddress ? (
+                <>
+                  <p>{truncateHOPRPeerId(nodeHoprAddress)}</p>
+                  <SquaredIconButton
+                    onClick={() => nodeHoprAddress && navigator.clipboard.writeText(nodeHoprAddress)}
                   >
-                    <SettingsIcon />
-                  </StyledIconButton>
-                  <StyledIconButton disabled>
-                    <CloseIcon />
-                  </StyledIconButton>
-                </NodeInfoRow>
-              </NodeInfo>
-            </Graphic>
-          </GrayCard>
-          <GrayCard
-            id="remaining-wxhopr-allowance"
-            title="Remaining wxHOPR Allowance"
-            value={wxHoprAllowance ?? '-'}
-            currency="wxHOPR"
-            buttons={[
-              {
-                text: 'Adjust',
-                link: '/staking/set-allowance',
-              },
-            ]}
-          ></GrayCard>
-          <GrayCard
-            id="earned-rewards"
-            title="Earned rewards"
-            value="-"
-            currency="wxHOPR"
-            // chip={{
-            //   label: '-%/24h',
-            //   color: 'error',
-            // }}
-          />
-          {/* <GrayCard
+                    <CopyIcon />
+                  </SquaredIconButton>
+                  <Link to={`https://gnosisscan.io/address/${nodeNativeAddress}`}>
+                    <SquaredIconButton>
+                      <LaunchIcon />
+                    </SquaredIconButton>
+                  </Link>
+                </>
+              ) : (
+                <p>-</p>
+              )}
+            </NodeInfoRow>
+            <NodeInfoRow>
+              <p>Last seen</p>
+              <p>- mins</p>
+            </NodeInfoRow>
+            <NodeInfoRow>
+              <p>Ping</p>
+              <p>-</p>
+            </NodeInfoRow>
+            <NodeInfoRow>
+              <p>24h Avail.</p>
+              <p>-%</p>
+            </NodeInfoRow>
+            <NodeInfoRow>
+              <p>Availability</p>
+              <p>-%</p>
+            </NodeInfoRow>
+            <NodeInfoRow>
+              <p id="actions">Actions</p>
+              <StyledIconButton
+                onClick={() => { } /*navigate(`/node/configuration?${queryParams}`)*/}
+                disabled
+              >
+                <SettingsIcon />
+              </StyledIconButton>
+              <StyledIconButton disabled>
+                <CloseIcon />
+              </StyledIconButton>
+            </NodeInfoRow>
+          </NodeInfo>
+        </Graphic>
+      </GrayCard>
+      <GrayCard
+        // id="xdai"
+        id="node-balance"
+        title="xDAI"
+        value={nodeBalance ?? '-'}
+      ></GrayCard>
+      <GrayCard
+        id="earned-rewards"
+        title="Earned rewards"
+        value="-"
+        currency="wxHOPR"
+      // chip={{
+      //   label: '-%/24h',
+      //   color: 'error',
+      // }}
+      />
+      {/* <GrayCard
             id="node-strategy"
             title="Node strategy"
             value={'-'}
@@ -351,23 +341,18 @@ const NodeAdded = () => {
               },
             ]}
           ></GrayCard> */}
-          <GrayCard
-            id="redeemed-tickets"
-            title="Redeemed Tickets"
-            value="-"
-            currency="Ticket/wxHOPR"
-            // chip={{
-            //   label: '+%/24h',
-            //   color: 'success',
-            // }}
-          ></GrayCard>
-          <GrayCard
-           // id="xdai"
-            id="node-balance"
-            title="xDAI"
-            value={nodeBalance ?? '-'}
-          ></GrayCard>
-        </Content>
+      <GrayCard
+        id="redeemed-tickets"
+        title="Redeemed Tickets"
+        value="-"
+        currency="Ticket/wxHOPR"
+      // chip={{
+      //   label: '+%/24h',
+      //   color: 'success',
+      // }}
+      ></GrayCard>
+
+    </Content>
   );
 };
 

--- a/src/pages/staking-hub/dashboard/staking.tsx
+++ b/src/pages/staking-hub/dashboard/staking.tsx
@@ -47,13 +47,16 @@ const Content = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 2rem;
+    width: 100%;
   }
 
-  #wxhopr-total-stake {
-    flex: 1;
+  .half-line {
+    display: flex;
+    flex-wrap: wrap;
+    width: calc(50% - 1rem);
   }
 
-  #xdai-in-safe {
+  #redeemed-tickets, #earned-rewards, #wxhopr-total-stake, #xdai-in-safe, #remaining-wxhopr-allowance {
     flex: 1;
   }
 
@@ -222,6 +225,8 @@ const StakingScreen = () => {
   const selectedSafeAddress = useAppSelector((store) => store.safe.selectedSafeAddress.data) as `0x${string}`;
   const moduleAddress = useAppSelector((store) => store.stakingHub.onboarding.moduleAddress) as `0x${string}`;
   const safeBalance = useAppSelector((store) => store.safe.balance.data);
+  const wxHoprAllowance = useAppSelector((store) => store.stakingHub.safeInfo.data.allowance.wxHoprAllowance);
+
   const [openBuyModal, set_openBuyModal] = useState(false);
 
   return (
@@ -340,6 +345,21 @@ const StakingScreen = () => {
           //   label: '-%/24h',
           //   color: 'error',
           // }}
+          />
+        </div>
+        <div className='half-line'>
+          <GrayCard
+            id="remaining-wxhopr-allowance"
+            title="Remaining wxHOPR Allowance
+            to Channels"
+            value={wxHoprAllowance ?? '-'}
+            currency="wxHOPR"
+            buttons={[
+              {
+                text: 'Adjust',
+                link: '/staking/set-allowance',
+              },
+            ]}
           />
         </div>
         <BuyXHopr


### PR DESCRIPTION
Fixes #372 

## Definition of done:

- [x] Dashboard - #staking: make 'Redeemed Tickets' 50% width of the card
- [x] Dashboard - #staking: make 'Earned Tickets' 50% width of the card
- [x] Dashboard - #staking: Allowance
  - [x] move the Remaining wxHOPR Allowance from #node tab to #staking,
  - [x] make it 50% width of the card
  - [x] place it under 'Redeemed Tickets'
  - [x] call it Remaining wxHOPR Allowance to Channels
- [x] Dashboard - #node: Use remaining space for Node balance
---

### Screens
Staking:
<img width="1226" alt="image" src="https://github.com/hoprnet/hopr-admin/assets/32660456/ed3a821d-878c-48dd-b15d-d494684dc0ea">
Node:
<img width="1206" alt="image" src="https://github.com/hoprnet/hopr-admin/assets/32660456/784d9dd6-7d23-4f7e-8e8b-24e318451bfd">
 
