### PR TITLE
Sets ALLOW_ALL on all Channel and Token operations by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopr-admin",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -1127,6 +1127,9 @@ const createSafeWithConfigThunk = createAsyncThunk<
         encodePacked(['bytes20', 'string'], [superWalletClient.account.address, Date.now().toString()]),
       );
 
+      // Sets ALLOW_ALL on all Channel and Token operations by default.
+      const defaultTarget = toBytes(HOPR_CHANNELS_SMART_CONTRACT_ADDRESS + "113333333333");
+      
       const {
         result,
         request,
@@ -1139,7 +1142,7 @@ const createSafeWithConfigThunk = createAsyncThunk<
           HOPR_NODE_MANAGEMENT_MODULE,
           payload.config.owners,
           saltNonce,
-          toHex(new Uint8Array(toBytes(HOPR_CHANNELS_SMART_CONTRACT_ADDRESS)), { size: 32 }),
+          toHex(new Uint8Array(defaultTarget), { size: 32 }),
         ],
       });
 

--- a/src/store/slices/safe/actionsAsync.ts
+++ b/src/store/slices/safe/actionsAsync.ts
@@ -1128,7 +1128,7 @@ const createSafeWithConfigThunk = createAsyncThunk<
       );
 
       // Sets ALLOW_ALL on all Channel and Token operations by default.
-      const defaultTarget = toBytes(HOPR_CHANNELS_SMART_CONTRACT_ADDRESS + "113333333333");
+      const defaultTarget = toBytes(HOPR_CHANNELS_SMART_CONTRACT_ADDRESS + "010103030303030303030303");
       
       const {
         result,


### PR DESCRIPTION
The previous setting set all permissions to BLOCK_ALL, preventing any node operations.