### PR TITLE
Add disabled prop to modals

### DIFF
--- a/src/components/Modal/node/AddAliasModal.tsx
+++ b/src/components/Modal/node/AddAliasModal.tsx
@@ -15,6 +15,7 @@ import Button from '../../../future-hopr-lib-components/Button';
 type CreateAliasModalProps = {
   handleRefresh: () => void;
   peerId?: string;
+  disabled?: boolean;
 };
 
 export const CreateAliasModal = (props: CreateAliasModalProps) => {
@@ -109,6 +110,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
           </span>
         }
         onClick={handleOpenModal}
+        disabled={props.disabled}
       />
       <SDialog
         open={openModal}

--- a/src/components/Modal/node/OpenOrFundChannelModal.tsx
+++ b/src/components/Modal/node/OpenOrFundChannelModal.tsx
@@ -23,6 +23,7 @@ type OpenOrFundChannelModalProps = {
   actionBtnText?: string;
   title?: string;
   type?: 'open' | 'fund';
+  disabled?: boolean;
 };
 
 export const OpenOrFundChannelModal = ({
@@ -116,7 +117,7 @@ export const OpenOrFundChannelModal = ({
     <>
       <IconButton
         iconComponent={icon()}
-        disabled={type === 'fund'}
+        disabled={type === 'fund' || props.disabled}
         tooltipText={
           type === 'fund' ?
             <span>

--- a/src/components/Modal/node/PingModal.tsx
+++ b/src/components/Modal/node/PingModal.tsx
@@ -13,6 +13,7 @@ import Button from '../../../future-hopr-lib-components/Button';
 
 type PingModalProps = {
   peerId?: string;
+  disabled?: boolean;
 };
 
 export const PingModal = (props: PingModalProps) => {
@@ -99,6 +100,7 @@ export const PingModal = (props: PingModalProps) => {
           </span>
         }
         onClick={handleOpenModal}
+        disabled={props.disabled}
       />
       <SDialog
         open={openModal}

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -37,9 +37,10 @@ const StatusContainer = styled.div`
 
 type SendMessageModalProps = {
   peerId?: string;
+  disabled?: boolean;
 };
 
-export const SendMessageModal = ({ peerId }: SendMessageModalProps) => {
+export const SendMessageModal = (props: SendMessageModalProps) => {
   const dispatch = useAppDispatch();
   const [path, set_path] = useState<string>('');
   const [loader, set_loader] = useState<boolean>(false);
@@ -47,7 +48,7 @@ export const SendMessageModal = ({ peerId }: SendMessageModalProps) => {
   const [numberOfHops, set_numberOfHops] = useState<number | ''>('');
   const [sendMode, set_sendMode] = useState<'path' | 'automaticPath' | 'numberOfHops' | 'directMessage' | 'none'>('directMessage');
   const [message, set_message] = useState<string>('');
-  const [receiver, set_receiver] = useState<string>(peerId ? peerId : '');
+  const [receiver, set_receiver] = useState<string>(props.peerId ? props.peerId : '');
   const [openModal, set_openModal] = useState<boolean>(false);
 
   const maxLength = 500;
@@ -60,15 +61,15 @@ export const SendMessageModal = ({ peerId }: SendMessageModalProps) => {
 
   useEffect(() => {
     switch (sendMode) {
-    case 'path':
-      set_numberOfHops('');
-      break;
-    case 'numberOfHops':
-      set_path('');
-      break;
-    default: //anything that is not a custom route
-      set_numberOfHops('');
-      set_path('');
+      case 'path':
+        set_numberOfHops('');
+        break;
+      case 'numberOfHops':
+        set_path('');
+        break;
+      default: //anything that is not a custom route
+        set_numberOfHops('');
+        set_path('');
     }
   }, [sendMode, path, numberOfHops]);
 
@@ -148,7 +149,7 @@ export const SendMessageModal = ({ peerId }: SendMessageModalProps) => {
     set_sendMode('directMessage');
     set_numberOfHops('');
     set_message('');
-    set_receiver(peerId ? peerId : '');
+    set_receiver(props.peerId ? props.peerId : '');
     set_path('');
     set_openModal(false);
     set_status('');
@@ -179,6 +180,7 @@ export const SendMessageModal = ({ peerId }: SendMessageModalProps) => {
           </span>
         }
         onClick={handleOpenModal}
+        disabled={props.disabled}
       />
 
       <SDialog

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -122,8 +122,6 @@ function AliasesPage() {
   }
 
   const parsedTableData = Object.entries(aliases ?? {}).map(([alias, peerId], key) => {
-    console.log(`PEERID: ${peerId}`)
-    console.log(`HOPR ADDRESS: ${hoprAddresses}`)
     return {
       id: peerId,
       key: key.toString(),

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -234,10 +234,12 @@ function DeleteAliasButton({
   alias,
   onError,
   onSuccess,
+  disabled,
 }: {
   alias: string;
   onError: (e: typeof APIError.prototype) => void;
   onSuccess: () => void;
+  disabled?: boolean;
 }) {
   const dispatch = useAppDispatch();
   const loginData = useAppSelector((store) => store.auth.loginData);
@@ -269,6 +271,7 @@ function DeleteAliasButton({
             .catch((e) => onError(e));
         }
       }}
+      disabled={disabled}
     />
   );
 }

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -27,6 +27,7 @@ function AliasesPage() {
   const aliases = useAppSelector((store) => store.node.aliases.data);
   const peers = useAppSelector(store => store.node.peers.data)
   const aliasesFetching = useAppSelector((store) => store.node.aliases.isFetching);
+  const hoprAddresses = useAppSelector((store) => store.node.addresses.data.hopr)
   const loginData = useAppSelector((store) => store.auth.loginData);
   const [importSuccess, set_importSuccess] = useState(false);
   const [deleteSuccess, set_deleteSuccess] = useState(false);
@@ -67,7 +68,7 @@ function AliasesPage() {
     if (!peer) {
       return;
     }
-    
+
     return peer.peerAddress
   }
 
@@ -121,6 +122,8 @@ function AliasesPage() {
   }
 
   const parsedTableData = Object.entries(aliases ?? {}).map(([alias, peerId], key) => {
+    console.log(`PEERID: ${peerId}`)
+    console.log(`HOPR ADDRESS: ${hoprAddresses}`)
     return {
       id: peerId,
       key: key.toString(),
@@ -129,12 +132,13 @@ function AliasesPage() {
       peerAddress: getPeerAddressByPeerId(peerId) ?? '',
       actions: (
         <>
-          <PingModal peerId={peerId} />
+          <PingModal peerId={peerId} disabled={peerId === hoprAddresses} />
           <OpenOrFundChannelModal
             peerAddress={getPeerAddressByPeerId(peerId)}
             type={'open'}
+            disabled={peerId === hoprAddresses}
           />
-          <SendMessageModal peerId={peerId} />
+          <SendMessageModal peerId={peerId} disabled={peerId === hoprAddresses} />
           <DeleteAliasButton
             onSuccess={() => {
               set_deleteSuccess(true);


### PR DESCRIPTION
Fixes #399 

### Overview
This pull request adds the `disabled` prop to the Node Admin Modals:

- [x] OpenOrFundChannelModal
- [x] SendMessageModal
- [x] PingModal
- [x] AddAliasModal
- [x] DeleteAliasButton

Also it adds a check to Aliases page, where if peerId is equal to the node's hopr address, it disable all actions but the `remove alias`