### PR TITLE
Change nginx docker version + add run command on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Builds the Node Admin docker image with the name `node-admin`.
 
 ### `docker run -p 8080:80 node-admin`
 
-Runs the Node Admin doker image exposing the 8080 port.
+Runs the Node Admin container exposing the 8080 port.
 To access the Node Admin you should go to `http://localhost:8080/`

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ It correctly bundles React in production mode and optimizes the build for the be
 
 
 
-### `docker build -f ./scripts/NodeAdmin.Dockerfile .`
+### `docker build -t node-admin -f ./scripts/NodeAdmin.Dockerfile .`
 
-Builds the Node Admin docker image.
+Builds the Node Admin docker image with the name `node-admin`.
 
+### `docker run -p 8080:80 node-admin`
 
-
+Runs the Node Admin doker image exposing the 8080 port.
+To access the Node Admin you should go to `http://localhost:8080/`

--- a/scripts/NodeAdmin.Dockerfile
+++ b/scripts/NodeAdmin.Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 
 RUN yarn run build-node
 
-FROM nginx:1.25.2@sha256:48a84a0728cab8ac558f48796f901f6d31d287101bc8b317683678125e0d2d35 AS runtime
+FROM nginx:stable AS runtime
 
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*

--- a/scripts/NodeAdmin.Dockerfile
+++ b/scripts/NodeAdmin.Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 
 RUN yarn run build-node
 
-FROM nginx:stable AS runtime
+FROM nginx:stable@sha256:5be2b646dfda41632549b19795721e3e676903c7d94567838fb1aa0e39ae1bfc AS runtime
 
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*


### PR DESCRIPTION
### Overview

- While testing the docker image generated from the command, it was noticed that there were some io_setup() related errors. To fix them the `nginx` image was changed to the stable version.
- The docker run command was also added to the README