### PR TITLE
Add filter to remove consecutive or trailing commas

### DIFF
--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -119,7 +119,6 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
     if (sendMode == 'path') {
       const pathElements: string[] = [];
       const lines = path.split('\n')
-      console.log(lines)
       for (const line of lines) {
         const elements = line.split(',').map((element) => element.trim()).filter((element) => element !== '');
         pathElements.push(...elements);

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -131,21 +131,20 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
       messagePayload.path = validatedPath;
     }
 
-    console.log(messagePayload)
-    // dispatch(actionsAsync.sendMessageThunk(messagePayload))
-    //   .unwrap()
-    //   .then((res) => {
-    //     console.log('@message: ', res?.challenge);
-    //     set_status('Message sent');
-    //     handleCloseModal();
-    //   })
-    //   .catch((e) => {
-    //     console.log('@message err:', e);
-    //     set_status(e.error);
-    //   })
-    //   .finally(() => {
-    //     set_loader(false);
-    //   });
+    dispatch(actionsAsync.sendMessageThunk(messagePayload))
+      .unwrap()
+      .then((res) => {
+        console.log('@message: ', res?.challenge);
+        set_status('Message sent');
+        handleCloseModal();
+      })
+      .catch((e) => {
+        console.log('@message err:', e);
+        set_status(e.error);
+      })
+      .finally(() => {
+        set_loader(false);
+      });
   };
 
   const handleSendModeChange = (event: SelectChangeEvent) => {

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -117,25 +117,35 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
       }
     }
     if (sendMode == 'path') {
-      const pathElements = path.replace(/(\r\n|\n|\r| )/gm, '').split(',');
+      const pathElements = path
+        .split('\n')
+        .map((line) =>
+          line
+            .split(',')
+            .map((element) => element.trim())
+            .filter((element) => element !== '')
+        )
+        .flat();
+
       const validatedPath = pathElements.map((element) => validatePeerId(element));
       messagePayload.path = validatedPath;
     }
 
-    dispatch(actionsAsync.sendMessageThunk(messagePayload))
-      .unwrap()
-      .then((res) => {
-        console.log('@message: ', res?.challenge);
-        set_status('Message sent');
-        handleCloseModal();
-      })
-      .catch((e) => {
-        console.log('@message err:', e);
-        set_status(e.error);
-      })
-      .finally(() => {
-        set_loader(false);
-      });
+    console.log(messagePayload)
+    // dispatch(actionsAsync.sendMessageThunk(messagePayload))
+    //   .unwrap()
+    //   .then((res) => {
+    //     console.log('@message: ', res?.challenge);
+    //     set_status('Message sent');
+    //     handleCloseModal();
+    //   })
+    //   .catch((e) => {
+    //     console.log('@message err:', e);
+    //     set_status(e.error);
+    //   })
+    //   .finally(() => {
+    //     set_loader(false);
+    //   });
   };
 
   const handleSendModeChange = (event: SelectChangeEvent) => {

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -117,15 +117,14 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
       }
     }
     if (sendMode == 'path') {
-      const pathElements = path
-        .split('\n')
-        .map((line) =>
-          line
-            .split(',')
-            .map((element) => element.trim())
-            .filter((element) => element !== '')
-        )
-        .flat();
+      const pathElements: string[] = [];
+      const lines = path.split('\n')
+      console.log(lines)
+      for (const line of lines) {
+        const elements = line.split(',').map((element) => element.trim()).filter((element) => element !== '');
+        pathElements.push(...elements);
+      }
+
 
       const validatedPath = pathElements.map((element) => validatePeerId(element));
       messagePayload.path = validatedPath;


### PR DESCRIPTION
Fixes #449 

# Overview

Remove trailing or consecutive commas. Example problem messagePayload:
```
{
    “apiToken":"Example-api-token",
    "apiEndpoint":"http://apiEndpoint:3001/",
    "body":"ejemplo",
    "peerId":"ejemplo",
    "tag":1,
    "path":[
        "",
        "abc",
        "",
        "def",
        "cba”,
        ””
    ]
}
```

How it looks before sending to sdk (after filtering):
```
{
    "apiToken": "Example-api-token",
    "apiEndpoint": "http://apiEndpoint:3001/",
    "body": "ejemplo",
    "peerId": "ejemplo",
    "tag": 1,
    "path": [
        "abc",
        "def",
        "cba"
    ]
}
```


---
### Note:
This is done when we are abou to send the message, so the messageModal itself doesn't update the content of the path field