### PR TITLE
Update to a Select for the receiver field

### DIFF
--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -90,13 +90,7 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
         set_numberOfHops(0);
         set_path('');
     }
-    if (!(loginData.apiEndpoint && loginData.apiToken)) return;
-    dispatch(actionsAsync.getPeersThunk({
-      apiToken: loginData.apiToken,
-      apiEndpoint: loginData.apiEndpoint
-    }))
-    console.log(peers)
-    console.log(aliases)
+
   }, [sendMode, path, numberOfHops]);
 
   const handleSendMessage = () => {

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -260,11 +260,11 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
         </TopBar>
         <SDialogContent
         >
+          <span style={{ margin: '0px 0px -2px' }}>Receiver:</span>
           <Select
             value={receiver}
-            onChange={handleChangeReceiver}
-            label="Receiver (Peer Id)">
-            {peers!.map((peer, index) =>
+            onChange={handleChangeReceiver}>
+            {peers!.map((peer) =>
               <MenuItem value={peer.peerId}>{hasAlias(peer.peerId) ? `${findAlias(peer.peerId)} (${peer.peerId})` : peer.peerId}</MenuItem>
             )}
           </Select>

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -50,18 +50,6 @@ const PathOrHops = styled.div`
 
 `;
 
-const StyledSelect = styled(Select)`
-
-.alternatingMenuItemGrey {
-  background-color: grey;
-}
-
-.alternatingMenuItemBlue {
-  background-color: blue;
-}
-`;
-
-
 const StatusContainer = styled.div`
   height: 32px;
 `;
@@ -278,22 +266,14 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
         </TopBar>
         <SDialogContent
         >
-          {/* <TextField
-            label="Receiver (Peer Id)"
-            placeholder="16Uiu2..."
-            value={receiver}
-            onChange={(e) => set_receiver(e.target.value)}
-            required
-            fullWidth
-          /> */}
-          <StyledSelect
+          <Select
             value={receiver}
             onChange={handleChangeReceiver}
             label="Receiver (Peer Id)">
             {peers!.map((peer, index) =>
-              <MenuItem className={index % 2 === 0 ? 'alternatingMenuItemGrey' : 'alternatingMenuItemBlue'} value={peer.peerId}>{hasAlias(peer.peerId) ? `${findAlias(peer.peerId)} (${peer.peerId})` : peer.peerId}</MenuItem>
+              <MenuItem value={peer.peerId}>{hasAlias(peer.peerId) ? `${findAlias(peer.peerId)} (${peer.peerId})` : peer.peerId}</MenuItem>
             )}
-          </StyledSelect>
+          </Select>
 
           <TextField
             label="Message"

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -73,16 +73,6 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
   const aliases = useAppSelector((store) => store.node.aliases.data);
   const peers = useAppSelector((store) => store.node.peers.data?.connected)
 
-  const findReceiver = (peerId: string) => {
-    if (peers) {
-      for (const peer of peers) {
-        if (peer.peerId === peerId)
-          return peer;
-      }
-    }
-    return null;
-  }
-
   const [selectedReceiver, set_selectedReceiver] = useState<{
     peerId: string;
     peerAddress: string;
@@ -96,7 +86,7 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
     backoff: number;
     isNew: boolean;
     reportedVersion: string;
-  } | null>(props.peerId ? findReceiver(props.peerId) : null);
+  } | null>(props.peerId ? peers!.find(elem => elem.peerId === props.peerId) || null : null);
 
   const maxLength = 500;
   const remainingChars = maxLength - message.length;
@@ -278,7 +268,6 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
         </TopBar>
         <SDialogContent
         >
-          <span style={{ margin: '0px 0px -2px' }}>Receiver:</span>
           <Autocomplete
             value={selectedReceiver}
             onChange={(event, newValue) => {

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -68,7 +68,6 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
   const [numberOfHops, set_numberOfHops] = useState<number>(0);
   const [sendMode, set_sendMode] = useState<'path' | 'automaticPath' | 'numberOfHops' | 'directMessage'>('directMessage');
   const [message, set_message] = useState<string>('');
-  const [receiver, set_receiver] = useState<string>(props.peerId ? props.peerId : '');
   const [openModal, set_openModal] = useState<boolean>(false);
   const loginData = useAppSelector((store) => store.auth.loginData);
   const aliases = useAppSelector((store) => store.node.aliases.data);
@@ -146,22 +145,21 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
       const validatedPath = pathElements.map((element) => validatePeerId(element));
       messagePayload.path = validatedPath;
     }
-    console.log(messagePayload)
 
-    // dispatch(actionsAsync.sendMessageThunk(messagePayload))
-    //   .unwrap()
-    //   .then((res) => {
-    //     console.log('@message: ', res?.challenge);
-    //     set_status('Message sent');
-    //     handleCloseModal();
-    //   })
-    //   .catch((e) => {
-    //     console.log('@message err:', e);
-    //     set_status(e.error);
-    //   })
-    //   .finally(() => {
-    //     set_loader(false);
-    //   });
+    dispatch(actionsAsync.sendMessageThunk(messagePayload))
+      .unwrap()
+      .then((res) => {
+        console.log('@message: ', res?.challenge);
+        set_status('Message sent');
+        handleCloseModal();
+      })
+      .catch((e) => {
+        console.log('@message err:', e);
+        set_status(e.error);
+      })
+      .finally(() => {
+        set_loader(false);
+      });
   };
 
   const handleSendModeChange = (event: SelectChangeEvent) => {


### PR DESCRIPTION
Fixes #444

# Overview

This changes the Textfield that was used to the Receiver, for a Select component, to let the user choose from the peers instead of having to type the peerId. 

It displays the peers as `alias (PeerId)` if an alias exists for that peer, else it shows `peerId`