### PR TITLE
Add login to node by url success or fail goal tracking

### DIFF
--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -163,6 +163,7 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
     const existingItem = nodesSavedLocally[existingItemIndex] as ParsedNode;
     if (existingItem && existingItem.apiToken.length > 0 && loginData.apiToken === existingItem.apiToken)
       set_saveApiToken(true);
+    console.log("HERE TOO")
   }, [loginData]);
 
   useEffect(() => {
@@ -181,7 +182,7 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
     if (loginData.apiToken) {
       set_apiToken(loginData.apiToken);
     }
-
+    console.log("HERE USE EFFECT")
     // If have have saved the node with the same apiToken, we check the saveApiToken checkbox
     const existingItemIndex = nodesSavedLocally.findIndex(
       (item) => item.apiEndpoint === loginData.apiEndpoint && item.apiToken === loginData.apiToken,

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -163,7 +163,6 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
     const existingItem = nodesSavedLocally[existingItemIndex] as ParsedNode;
     if (existingItem && existingItem.apiToken.length > 0 && loginData.apiToken === existingItem.apiToken)
       set_saveApiToken(true);
-    console.log("HERE TOO")
   }, [loginData]);
 
   useEffect(() => {
@@ -182,7 +181,6 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
     if (loginData.apiToken) {
       set_apiToken(loginData.apiToken);
     }
-    console.log("HERE USE EFFECT")
     // If have have saved the node with the same apiToken, we check the saveApiToken checkbox
     const existingItemIndex = nodesSavedLocally.findIndex(
       (item) => item.apiEndpoint === loginData.apiEndpoint && item.apiToken === loginData.apiToken,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -74,6 +74,7 @@ import { stakingHubActions } from './store/slices/stakingHub';
 import TermsOfService from './pages/TermsOfService';
 import PrivacyNotice from './pages/PrivacyNotice';
 import MetaMaskFox from './future-hopr-lib-components/Icons/MetaMaskFox';
+import { trackGoal } from 'fathom-client';
 
 export type ApplicationMapType = {
   groupName: string;
@@ -375,6 +376,8 @@ const LayoutEnhanced = () => {
           })
         ).unwrap();
         if (loginInfo) {
+          // We do this after the loginInfo to make sure the login from url was successful
+          trackGoal('Y641EPNA', 1) // LOGIN_TO_NODE_BY_URL
           dispatch(
             nodeActionsAsync.getInfoThunk({
               apiToken,
@@ -402,6 +405,7 @@ const LayoutEnhanced = () => {
           dispatch(nodeActions.initializeMessagesWebsocket());
         }
       } catch (e) {
+        trackGoal('ZUIBL4M8', 1) // FAILED_CONNECT_TO_NODE_BY_URL
         // error is handled on redux
       }
     };


### PR DESCRIPTION
Fixes #416 

# Overview

Adds goal tracking for:
- [x]  FAILED_CONNECT_TO_NODE_BY_URL
- [x] LOGIN_TO_NODE_BY_URL
