### PR TITLE
Update import of aliases to use async-await

### DIFF
--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -85,10 +85,10 @@ function AliasesPage() {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleCSVUpload = (parsedData: any[]) => {
+  const handleCSVUpload = async (parsedData: any[]) => {
     for (const data of parsedData) {
       if (data.alias && data.peerId && loginData.apiEndpoint && loginData.apiToken) {
-        dispatch(
+        await dispatch(
           actionsAsync.setAliasThunk({
             alias: String(data.alias),
             peerId: String(data.peerId),


### PR DESCRIPTION
Fixes #471 

# Overview

This function didn't have async await, to result of this was all the request being executed at the same time, since we have a condition where if a function is called while it's already executing, we were cancelling before it's execution (refer to: https://redux-toolkit.js.org/api/createAsyncThunk\#canceling-before-execution).

When using await to lock the execution to not be parallel it works as expected

## Demo Result
![Screen Recording 2023-10-30 at 06 27 06](https://github.com/hoprnet/hopr-admin/assets/32660456/c333729b-edaa-4c87-8749-bc1d9bb22e4a)
