### PR TITLE
Node PeerID copy button and remove web3 login froe Node Admin mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopr-admin",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/src/pages/node/info.tsx
+++ b/src/pages/node/info.tsx
@@ -319,7 +319,18 @@ function InfoPage() {
                   <span>Node PeerID</span>
                 </Tooltip>
               </th>
-              <td>{addresses?.hopr}</td>
+              <TdActionIcons>
+                {addresses?.hopr}
+                {
+                  addresses?.hopr &&
+                  <SmallActionButton
+                    onClick={() => navigator.clipboard.writeText(addresses?.hopr as string)}
+                    tooltip={'Copy'}
+                  >
+                    <CopyIcon />
+                  </SmallActionButton>
+                }
+              </TdActionIcons>
             </tr>
             <tr>
               <th>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -483,7 +483,7 @@ const LayoutEnhanced = () => {
       drawer
       webapp
       drawerItems={applicationMap}
-      drawerFunctionItems={drawerFunctionItems}
+      drawerFunctionItems={environment === 'web3' ? drawerFunctionItems : undefined}
       drawerLoginState={{
         node: nodeConnected,
         web3: web3Connected,


### PR DESCRIPTION
Changelog:
- Node PeerID copy button on the info page
- remove web3 (Staking Hub) login from Drawer Node Admin mobile