### PR TITLE
2.1.5: On-chain timeouts, closure channel error made better, Last indexed block in Info subpage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "hopr-admin",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.0",
-    "@hoprnet/hopr-sdk": "2.1.3-beta.2",
+    "@hoprnet/hopr-sdk": "2.1.6",
     "@metamask/jazzicon": "^2.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",

--- a/src/components/Modal/node/FundChannelModal.tsx
+++ b/src/components/Modal/node/FundChannelModal.tsx
@@ -47,7 +47,7 @@ export const FundChannelModal = ({ ...props }: FundChannelModalModalProps) => {
           apiToken: loginData.apiToken ? loginData.apiToken : '',
           amount: weiValue,
           channelId: channelId,
-          timeout: 60e3,
+          timeout: 240_000, //TODO: put those values as default to HOPRd SDK, average is 50s
         }),
       )
         .unwrap()

--- a/src/components/Modal/node/FundChannelModal.tsx
+++ b/src/components/Modal/node/FundChannelModal.tsx
@@ -47,7 +47,7 @@ export const FundChannelModal = ({ ...props }: FundChannelModalModalProps) => {
           apiToken: loginData.apiToken ? loginData.apiToken : '',
           amount: weiValue,
           channelId: channelId,
-          timeout: 240_000, //TODO: put those values as default to HOPRd SDK, average is 50s
+          timeout: 120_000, //TODO: put those values as default to HOPRd SDK, average is 50s
         }),
       )
         .unwrap()

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -146,13 +146,13 @@ function ChannelsPage() {
   ];
 
   const handleCloseChannel = (channelId: string) => {
-    const usedApiEndpoint = loginData.apiEndpoint;
     console.log('handleCloseChannel', channelId);
     dispatch(
       actionsAsync.closeChannelThunk({
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken ? loginData.apiToken : '',
         channelId: channelId,
+        timeout: 120_000  //TODO: put those values as default to HOPRd SDK, average is 50s
       }),
     )
       .unwrap()

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -152,7 +152,7 @@ function ChannelsPage() {
         apiEndpoint: loginData.apiEndpoint!,
         apiToken: loginData.apiToken ? loginData.apiToken : '',
         channelId: channelId,
-        timeout: 120_000  //TODO: put those values as default to HOPRd SDK, average is 50s
+        timeout: 120_000, //TODO: put those values as default to HOPRd SDK, average is 50s
       }),
     )
       .unwrap()

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -107,6 +107,21 @@ function ChannelsPage() {
         ).unwrap();
         if (!isCurrentApiEndpointTheSame) return;
 
+        if (e instanceof sdkApiError && e.hoprdErrorPayload?.error?.includes('channel closure time has not elapsed yet, remaining')) {
+          let errMsg = `Closing of outgoing channel ${channelId} halted. C${e.hoprdErrorPayload?.error.substring(1)}`;
+          sendNotification({
+            notificationPayload: {
+              source: 'node',
+              name: errMsg,
+              url: null,
+              timeout: null,
+            },
+            toastPayload: { message: errMsg },
+            dispatch,
+          });
+          return;
+        }
+
         let errMsg = `Closing of outgoing channel ${channelId} failed`;
         if (e instanceof sdkApiError && e.hoprdErrorPayload?.status)
           errMsg = errMsg + `.\n${e.hoprdErrorPayload.status}`;

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -107,7 +107,10 @@ function ChannelsPage() {
         ).unwrap();
         if (!isCurrentApiEndpointTheSame) return;
 
-        if (e instanceof sdkApiError && e.hoprdErrorPayload?.error?.includes('channel closure time has not elapsed yet, remaining')) {
+        if (
+          e instanceof sdkApiError &&
+          e.hoprdErrorPayload?.error?.includes('channel closure time has not elapsed yet, remaining')
+        ) {
           let errMsg = `Closing of outgoing channel ${channelId} halted. C${e.hoprdErrorPayload?.error.substring(1)}`;
           sendNotification({
             notificationPayload: {

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -59,6 +59,7 @@ function InfoPage() {
   const blockNumberCheckSumFromMetrics = useAppSelector((store) => store.node.metricsParsed.checksum); // <2.1.2
   const blockNumberFromInfo = useAppSelector((store) => store.node.info.data?.indexerBlock); // >=2.1.3
   const blockNumberCheckSumFromInfo = useAppSelector((store) => store.node.info.data?.indexerChecksum); // >=2.1.3
+  const blockNumberIndexedWithHOPRdata = useAppSelector((store) => store.node.info.data?.indexBlockPrevChecksum); // >=2.1.4
   const blockNumber = blockNumberFromMetrics ?? blockNumberFromInfo;
   const blockNumberCheckSum = blockNumberCheckSumFromMetrics ?? blockNumberCheckSumFromInfo;
 
@@ -290,10 +291,10 @@ function InfoPage() {
             <tr>
               <th>
                 <Tooltip
-                  title=""
+                  title="Last block that the node got from the RPC"
                   notWide
                 >
-                  <span>Block number</span>
+                  <span>Current block</span>
                 </Tooltip>
               </th>
               <td>{blockNumber ? blockNumber : '-'}</td>
@@ -301,7 +302,18 @@ function InfoPage() {
             <tr>
               <th>
                 <Tooltip
-                  title=""
+                  title="Last indexed block from the chain which contains HOPR data"
+                  notWide
+                >
+                  <span>Last indexed block</span>
+                </Tooltip>
+              </th>
+              <td>{blockNumberIndexedWithHOPRdata ? blockNumberIndexedWithHOPRdata : '-'}</td>
+            </tr>
+            <tr>
+              <th>
+                <Tooltip
+                  title="The latest hash of the node database"
                   notWide
                 >
                   <span>Block checksum</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hoprnet/hopr-sdk@2.1.3-beta.2":
-  version "2.1.3-beta.2"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-2.1.3-beta.2.tgz#8b0a9b83750e0d0fb9c6d8f70151dabc3284e738"
-  integrity sha512-gtSz2T+RkIKuQO/H7CAIAe0mLAoVpoka2ua+nYemD4U1XYXRZwTrxEnvxgxVIROw43E036ubtWys5qm7cG7N1g==
+"@hoprnet/hopr-sdk@2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-2.1.6.tgz#5672fc28db5468eb32e4e60378b4c7638cf86904"
+  integrity sha512-DPQN9OsXD0t3IhYTPEPg5vOV4uROtI2yhKRpUsWGofLLPtNTpYEHzqzAoJiHTESyYVB1wc+kpI8UGW4WNLyRww==
   dependencies:
     debug "^4.3.4"
     isomorphic-ws "^5.0.0"


### PR DESCRIPTION
## Changelog


- **New Features**
	- Updated the application version to 2.1.5.
	- Showing `Last indexed block` in the Info subpage
	- Enhanced error handling for outgoing channel closures, providing detailed notifications for specific 'channel closure time has not elapsed yet' error.

- **Improvements**
	- Increased timeout duration for API calls, allowing for longer wait time for on-chain operations (close and fund of channels).
	- Streamlined the code by removing unnecessary variables, enhancing code clarity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `InfoPage` to display the last indexed block containing HOPR data with improved tooltips for clarity.
	- Improved error handling in `ChannelsPage` for channel closure, providing users with detailed notifications on specific errors.

- **Improvements**
	- Increased timeout duration for channel funding operations to accommodate longer API calls.
	- Added a timeout parameter for closing channels, improving function flexibility.

- **Version Updates**
	- Updated project version to 2.1.5 and SDK dependency to 2.1.6 for new features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->