### PR TITLE
Port change inside docker from 80 to 4677

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 
 Builds the Node Admin docker image with the name `node-admin`.
 
-### `docker run -d -p 4677:80 --name hopr-admin --platform linux/amd64 europe-west3-docker.pkg.dev/hoprassociation/docker-images/hopr-admin`
+### `docker run -d -p 4677:4677 --name hopr-admin --platform linux/amd64 europe-west3-docker.pkg.dev/hoprassociation/docker-images/hopr-admin`
 
 Runs the Node Admin container exposing the 4677 port.
 To access the Node Admin you should go to `http://localhost:4677/`

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen       80;
+  listen       4677;
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Docker run command for the Node Admin container to map port 4677.
	- Nginx server configuration now listens on port 4677 instead of the default port 80.
- **Documentation**
	- Revised instructions in the README for accessing the Node Admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->