### PR TITLE
Last version for HOPRd 2.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopr-admin",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopr-admin",
-  "version": "2.1.13",
+  "version": "2.1.12",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -381,7 +381,7 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
               selectedReceiver === null ||
               (sendMode !== 'directMessage' && sendMode !== 'automaticPath' && numberOfHops < 0 && path === '') ||
               message.length === 0 ||
-              ((sendMode === 'directMessage' || numberOfHops < 1 ) && selectedReceiver === hoprAddress)
+              ((sendMode === 'directMessage' || numberOfHops < 1) && selectedReceiver === hoprAddress)
             }
             style={{
               width: '100%',

--- a/src/components/Modal/node/SendMessageModal.tsx
+++ b/src/components/Modal/node/SendMessageModal.tsx
@@ -106,6 +106,7 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
   const [message, set_message] = useState<string>('');
   const [openModal, set_openModal] = useState<boolean>(false);
   const loginData = useAppSelector((store) => store.auth.loginData);
+  const hoprAddress = useAppSelector((store) => store.node.addresses.data.hopr);
   const aliases = useAppSelector((store) => store.node.aliases.data);
   const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
   const peers = useAppSelector((store) => store.node.peers.data);
@@ -379,7 +380,8 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
             disabled={
               selectedReceiver === null ||
               (sendMode !== 'directMessage' && sendMode !== 'automaticPath' && numberOfHops < 0 && path === '') ||
-              message.length === 0
+              message.length === 0 ||
+              ((sendMode === 'directMessage' || numberOfHops < 1 ) && selectedReceiver === hoprAddress)
             }
             style={{
               width: '100%',

--- a/src/components/Modal/node/WithdrawModal.tsx
+++ b/src/components/Modal/node/WithdrawModal.tsx
@@ -104,19 +104,6 @@ const WithdrawModal = ({ initialCurrency }: WithdrawModalProps) => {
     set_openModal(false);
   };
 
-  // Testing:
-  useEffect(() => {
-    console.log({
-      recipient,
-      amount,
-      withdrawingZeroOrLess,
-      withdrawingMoreThanTheWallet,
-      ' parseEther(amount)': parseEther(amount),
-      'parseEther(maxAmount)': parseEther(maxAmount),
-      native: nativeBalance,
-    });
-  }, [recipient, amount, withdrawingZeroOrLess, withdrawingMoreThanTheWallet, maxAmount, nativeBalance]);
-
   const setAmount = () => {
     setMaxAmount();
     if (currency === 'HOPR' && hoprBalance.formatted) {

--- a/src/components/Modal/node/WithdrawModal.tsx
+++ b/src/components/Modal/node/WithdrawModal.tsx
@@ -106,8 +106,16 @@ const WithdrawModal = ({ initialCurrency }: WithdrawModalProps) => {
 
   // Testing:
   useEffect(() => {
-    console.log({recipient, amount, withdrawingZeroOrLess, withdrawingMoreThanTheWallet,  ' parseEther(amount)': parseEther(amount), 'parseEther(maxAmount)': parseEther(maxAmount), native: nativeBalance});
-  }, [recipient, amount, withdrawingZeroOrLess, withdrawingMoreThanTheWallet,maxAmount, nativeBalance]);
+    console.log({
+      recipient,
+      amount,
+      withdrawingZeroOrLess,
+      withdrawingMoreThanTheWallet,
+      ' parseEther(amount)': parseEther(amount),
+      'parseEther(maxAmount)': parseEther(maxAmount),
+      native: nativeBalance,
+    });
+  }, [recipient, amount, withdrawingZeroOrLess, withdrawingMoreThanTheWallet, maxAmount, nativeBalance]);
 
   const setAmount = () => {
     setMaxAmount();
@@ -249,14 +257,16 @@ const WithdrawModal = ({ initialCurrency }: WithdrawModalProps) => {
               }
               value={recipient}
               onChange={(e) => {
-                console.log('rec', e.target.value)
-                set_recipient(e.target.value)
+                console.log('rec', e.target.value);
+                set_recipient(e.target.value);
               }}
             />
             <Button
               onClick={handleWithdraw}
               pending={isLoading}
-              disabled={!recipient || !amount || withdrawingZeroOrLess || withdrawingMoreThanTheWallet || !validatedEthAddress}
+              disabled={
+                !recipient || !amount || withdrawingZeroOrLess || withdrawingMoreThanTheWallet || !validatedEthAddress
+              }
             >
               Withdraw
             </Button>

--- a/src/future-hopr-lib-components/PeerInfo/index.tsx
+++ b/src/future-hopr-lib-components/PeerInfo/index.tsx
@@ -35,7 +35,8 @@ const PeersInfo: React.FC<Props> = (props) => {
   const getAliasByPeerId = (peerId: string): string | JSX.Element => {
     const aliasPresent = aliases && peerId && peerIdToAliasLink[peerId];
     const shortPeerId = peerId && `${peerId.substring(0, 6)}...${peerId.substring(peerId.length - 8, peerId.length)}`;
-    const displayPeerId = props.shortenPeerId || (props.shortenPeerIdIfAliasPresent && aliasPresent) ? shortPeerId : peerId;
+    const displayPeerId =
+      props.shortenPeerId || (props.shortenPeerIdIfAliasPresent && aliasPresent) ? shortPeerId : peerId;
     if (aliasPresent)
       return (
         <>

--- a/src/future-hopr-lib-components/PeerInfo/index.tsx
+++ b/src/future-hopr-lib-components/PeerInfo/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   peerId?: string;
   nodeAddress?: string;
   shortenPeerId?: boolean;
+  shortenPeerIdIfAliasPresent?: boolean;
 }
 
 const Container = styled.div`
@@ -32,12 +33,13 @@ const PeersInfo: React.FC<Props> = (props) => {
   const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
 
   const getAliasByPeerId = (peerId: string): string | JSX.Element => {
+    const aliasPresent = aliases && peerId && peerIdToAliasLink[peerId];
     const shortPeerId = peerId && `${peerId.substring(0, 6)}...${peerId.substring(peerId.length - 8, peerId.length)}`;
-    const displayPeerId = props.shortenPeerId ? shortPeerId : peerId;
-    if (aliases && peerId && peerIdToAliasLink[peerId])
+    const displayPeerId = props.shortenPeerId || (props.shortenPeerIdIfAliasPresent && aliasPresent) ? shortPeerId : peerId;
+    if (aliasPresent)
       return (
         <>
-          <strong>{peerIdToAliasLink[peerId]}</strong> ({displayPeerId})
+          <strong>{aliasPresent}</strong> ({displayPeerId})
         </>
       );
     return displayPeerId;

--- a/src/future-hopr-lib-components/Section/index.tsx
+++ b/src/future-hopr-lib-components/Section/index.tsx
@@ -59,7 +59,7 @@ const SSection = styled.section`
 `;
 
 const Content = styled.div`
-  max-width: 1098px;
+  max-width: 1198px;
   margin: auto;
   display: flex;
   flex-direction: column;

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -461,7 +461,7 @@ function CSVUploader<T extends ParsedData>({ onParse }: CSVUploaderProps<T>) {
 
         for (let j = 0; j < header.length; j++) {
           const key = expectedObjectKeys[j];
-          const value = values[j]?.trim();
+          const value = values[j]?.trim().replaceAll(' ', '_');
           if (expectedObjectKeys.includes(key)) {
             dataObject[key as keyof T] = value as T[keyof T];
           }

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -253,7 +253,7 @@ function ChannelsPage() {
           <PeersInfo
             peerId={peerId}
             nodeAddress={peerAddress}
-            shortenPeerId
+            shortenPeerIdIfAliasPresent
           />
         ),
         peerAddress: getAliasByPeerAddress(peerAddress as string),

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -153,7 +153,7 @@ function ChannelsPage() {
     {
       key: 'node',
       name: 'Node',
-      maxWidth: '350px',
+      maxWidth: '500px',
     },
     {
       key: 'peerAddress',
@@ -178,7 +178,7 @@ function ChannelsPage() {
       key: 'funds',
       name: 'Dedicated Funds',
       tooltip: true,
-      maxWidth: '80px',
+      maxWidth: '45px',
     },
     {
       key: 'actions',
@@ -236,7 +236,7 @@ function ChannelsPage() {
           <PeersInfo
             peerId={peerId}
             nodeAddress={peerAddress}
-            shortenPeerId
+            shortenPeerIdIfAliasPresent
           />
         ),
         peerAddress: getAliasByPeerAddress(peerAddress as string),

--- a/src/pages/node/configuration.tsx
+++ b/src/pages/node/configuration.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { formatEther } from 'viem';
-import { rounder } from '../../utils/functions';
+import { rounder, rounder2 } from '../../utils/functions';
 
 // HOPR Components
 import { SubpageTitle } from '../../components/SubpageTitle';
@@ -29,7 +29,8 @@ interface StrategyConfig {
 }
 
 const calculateTickets = (value: string, ticketPrice: string) => {
-  const valueBigInt = BigInt(value) * DECIMALS_MULTIPLIER;
+  console.log({value, ticketPrice})
+  const valueBigInt = BigInt(value);
   const ticketBigInt = BigInt(ticketPrice);
   return valueBigInt / ticketBigInt;
 };
@@ -37,7 +38,7 @@ const calculateTickets = (value: string, ticketPrice: string) => {
 const updateStrategyString = (originalString: string, key: string, value: string, tickets: bigint): string => {
   const stringToReplace = `"${key}": "${value} HOPR"`;
   const formattedEther = formatEther(BigInt(value));
-  const replacement = `"${key}": "${value}" // ${formattedEther} HOPR, tickets: ${rounder(Number(tickets))}`;
+  const replacement = `"${key}": "${value}" // = ${formattedEther} HOPR (${rounder(Number(tickets))} tickets)`;
 
   return originalString.includes(stringToReplace + ',')
     ? originalString.replace(stringToReplace + ',', replacement + ',')

--- a/src/pages/node/configuration.tsx
+++ b/src/pages/node/configuration.tsx
@@ -38,7 +38,7 @@ const calculateTickets = (value: string, ticketPrice: string) => {
 const updateStrategyString = (originalString: string, key: string, value: string, tickets: bigint): string => {
   const stringToReplace = `"${key}": "${value} HOPR"`;
   const formattedEther = formatEther(BigInt(value));
-  const replacement = `"${key}": "${value}" // = ${formattedEther} HOPR (${rounder(Number(tickets))} tickets)`;
+  const replacement = `"${key}": "${value}" // = ${formattedEther} wxHOPR (${rounder(Number(tickets))} tickets)`;
 
   return originalString.includes(stringToReplace + ',')
     ? originalString.replace(stringToReplace + ',', replacement + ',')

--- a/src/pages/node/configuration.tsx
+++ b/src/pages/node/configuration.tsx
@@ -29,7 +29,7 @@ interface StrategyConfig {
 }
 
 const calculateTickets = (value: string, ticketPrice: string) => {
-  console.log({value, ticketPrice})
+  console.log({ value, ticketPrice });
   const valueBigInt = BigInt(value);
   const ticketBigInt = BigInt(ticketPrice);
   return valueBigInt / ticketBigInt;

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -67,7 +67,7 @@ function InfoPage() {
       ? blockNumberPrevIndexedWithHOPRdata + 1
       : null;
   const blockNumber = blockNumberFromInfo ?? blockNumberFromMetrics;
-  const blockNumberCheckSum = blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics;
+  const blockNumberCheckSum = (blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics) !== '0x0000000000000000000000000000000000000000000000000000000000000000' ? blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics : null;
   const ticketPrice = useAppSelector((store) => store.node.ticketPrice.data);
 
   useEffect(() => {

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -349,28 +349,33 @@ function InfoPage() {
               </th>
               <td>{blockNumber ? blockNumber : '-'}</td>
             </tr>
-            <tr>
-              <th>
-                <Tooltip
-                  title="Last indexed block from the chain which contains HOPR data"
-                  notWide
-                >
-                  <span>Last indexed block</span>
-                </Tooltip>
-              </th>
-              <td>{blockNumberIndexedWithHOPRdata ? blockNumberIndexedWithHOPRdata : '-'}</td>
-            </tr>
-            <tr>
-              <th>
-                <Tooltip
-                  title="The latest hash of the node database"
-                  notWide
-                >
-                  <span>Block checksum</span>
-                </Tooltip>
-              </th>
-              <td>{blockNumberCheckSum ? blockNumberCheckSum : '-'}</td>
-            </tr>
+            {(blockNumberIndexedWithHOPRdata || blockNumberCheckSum) && (
+              <>
+                <tr>
+                  <th>
+                    <Tooltip
+                      title="Last indexed block from the chain which contains HOPR data"
+                      notWide
+                    >
+                      <span>Last indexed block</span>
+                    </Tooltip>
+                  </th>
+                  <td>{blockNumberIndexedWithHOPRdata ? blockNumberIndexedWithHOPRdata : '-'}</td>
+                </tr>
+
+                <tr>
+                  <th>
+                    <Tooltip
+                      title="The latest hash of the node database"
+                      notWide
+                    >
+                      <span>Block checksum</span>
+                    </Tooltip>
+                  </th>
+                  <td>{blockNumberCheckSum ? blockNumberCheckSum : '-'}</td>
+                </tr>
+              </>
+            )}
           </tbody>
         </TableExtended>
 

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -67,7 +67,11 @@ function InfoPage() {
       ? blockNumberPrevIndexedWithHOPRdata + 1
       : null;
   const blockNumber = blockNumberFromInfo ?? blockNumberFromMetrics;
-  const blockNumberCheckSum = (blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics) !== '0x0000000000000000000000000000000000000000000000000000000000000000' ? blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics : null;
+  const blockNumberCheckSum =
+    (blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics) !==
+    '0x0000000000000000000000000000000000000000000000000000000000000000'
+      ? blockNumberCheckSumFromInfo ?? blockNumberCheckSumFromMetrics
+      : null;
   const ticketPrice = useAppSelector((store) => store.node.ticketPrice.data);
 
   useEffect(() => {

--- a/src/pages/node/peers.tsx
+++ b/src/pages/node/peers.tsx
@@ -166,7 +166,7 @@ function PeersPage() {
         <PeersInfo
           peerId={peer.peerId}
           nodeAddress={peer.peerAddress}
-          shortenPeerId
+          shortenPeerIdIfAliasPresent
         />
       ),
       peerId: getAliasByPeerId(peer.peerId),

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -40,6 +40,7 @@ export function rounder(value: number | string | null | undefined, charLength: n
   if (!value) return '-';
   if (value == 0) return '0';
   let splitted = ['', ''];
+  console.log('value', value)
   if (typeof value === 'string') {
     if (value.includes('.')) {
       splitted = value.split('.');
@@ -52,6 +53,7 @@ export function rounder(value: number | string | null | undefined, charLength: n
   } else {
     splitted = [`${value}`, '0'];
   }
+  console.log('splitted', splitted)
   const wholes = splitted[0];
   const decimas = splitted[1];
   let rez: string | null = null;

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -40,7 +40,7 @@ export function rounder(value: number | string | null | undefined, charLength: n
   if (!value) return '-';
   if (value == 0) return '0';
   let splitted = ['', ''];
-  console.log('value', value)
+  console.log('value', value);
   if (typeof value === 'string') {
     if (value.includes('.')) {
       splitted = value.split('.');
@@ -53,7 +53,7 @@ export function rounder(value: number | string | null | undefined, charLength: n
   } else {
     splitted = [`${value}`, '0'];
   }
-  console.log('splitted', splitted)
+  console.log('splitted', splitted);
   const wholes = splitted[0];
   const decimas = splitted[1];
   let rez: string | null = null;


### PR DESCRIPTION
Changelog:
- disable sending messaged to yourself using directpath
- show full PeerID under nodes list when there is no alias
- do not show last block checksum if it is not present in the API
- prevent spaces in the alias while importing aliases
- better parsing of number of tickets in the Strategies section
- validate eth address in withdrawl modal
- bugfix disabled withdraw button when the input amount is corrent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced peer ID display logic with new alias-based shortening option.
  - Improved address validation for withdrawals.

- **Bug Fixes**
  - Updated message sending validation to prevent sending messages to own address.
  - Fixed maximum amount initialization in withdrawal modal.

- **UI Improvements**
  - Adjusted column widths in channel tables.
  - Increased maximum width for content display.
  - Modified CSV parsing to replace spaces with underscores.

- **Chores**
  - Added additional logging for debugging purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->