### PR TITLE
add wei to token name for the withdraw endpoint

### DIFF
--- a/src/components/Modal/node/WithdrawModal.tsx
+++ b/src/components/Modal/node/WithdrawModal.tsx
@@ -143,7 +143,7 @@ const WithdrawModal = ({ initialCurrency }: WithdrawModalProps) => {
       set_transactionHash('');
       await dispatch(
         nodeActionsAsync.withdrawThunk({
-          amount: `${parseEther(amount).toString()} ${currency === 'NATIVE' ? 'xDai' : 'wxHOPR'}`,
+          amount: `${parseEther(amount).toString()} ${currency === 'NATIVE' ? 'wei xDai' : 'wei wxHOPR'}`,
           address: recipient,
           apiEndpoint,
           apiToken: apiToken ? apiToken : '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the display format for withdrawal amounts to include a "wei" prefix before the currency unit in withdrawal requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->