### PR TITLE
feat: Fix login, abort all calls on disconnect

### DIFF
--- a/src/LayoutEnhanced.tsx
+++ b/src/LayoutEnhanced.tsx
@@ -156,7 +156,8 @@ const LayoutEnhanced = () => {
       }
     };
     useNode();
-  }, [apiEndpoint, apiToken, loginData.apiEndpoint, loginData.apiToken]);
+    // run only on first mount — URL-driven auto-login
+  }, []);
 
   return (
     <Layout

--- a/src/LayoutEnhanced.tsx
+++ b/src/LayoutEnhanced.tsx
@@ -156,7 +156,6 @@ const LayoutEnhanced = () => {
       }
     };
     useNode();
-    // run only on first mount — URL-driven auto-login
   }, []);
 
   return (

--- a/src/components/ConnectNode/index.tsx
+++ b/src/components/ConnectNode/index.tsx
@@ -14,6 +14,7 @@ import { appActions } from '../../store/slices/app';
 
 //MUI
 import { Button, Menu, MenuItem, CircularProgress } from '@mui/material';
+import { abortAllPending } from '../../store/abortRegistry';
 
 const Container = styled(Button)`
   align-items: center;
@@ -152,10 +153,10 @@ export default function ConnectNode() {
   }, [openLoginModalToNode]);
 
   const handleLogout = () => {
+    abortAllPending();
     dispatch(authActions.resetState());
     dispatch(nodeActions.resetState());
     dispatch(appActions.resetNodeState());
-    //  dispatch(nodeActions.closeMessagesWebsocket());
     navigate('/');
   };
 

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -260,7 +260,6 @@ function ConnectNodeModal({ open = false, handleClose }: ConnectNodeModalProps) 
     abortAllPending();
     dispatch(authActions.resetState());
     dispatch(nodeActions.resetState());
-    abortAllPending;
     try {
       console.log('Node Admin login from modal');
       const loginInfo = await dispatch(
@@ -490,7 +489,7 @@ function ConnectNodeModal({ open = false, handleClose }: ConnectNodeModalProps) 
               color="primary"
               aria-label="close modal"
               onClick={() => {
-                dispatch(authActions.removeFailedLogin());
+                dispatch(authActions.resetState());
               }}
             >
               <CloseIcon />

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -259,7 +259,8 @@ function ConnectNodeModal({ open = false, handleClose }: ConnectNodeModalProps) 
     }
     abortAllPending();
     dispatch(authActions.resetState());
-    dispatch(nodeActions.resetState());abortAllPending
+    dispatch(nodeActions.resetState());
+    abortAllPending;
     try {
       console.log('Node Admin login from modal');
       const loginInfo = await dispatch(

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store';
+import { abortAllPending } from '../../store/abortRegistry';
 import styled from '@emotion/styled';
 import { trackGoal } from 'fathom-client';
 import { parseAndFormatUrl } from '../../utils/parseAndFormatUrl';
@@ -256,10 +257,9 @@ function ConnectNodeModal({ open = false, handleClose }: ConnectNodeModalProps) 
         apiEndpoint: formattedApiEndpoint,
       });
     }
+    abortAllPending();
     dispatch(authActions.resetState());
-    dispatch(nodeActions.resetState());
-    dispatch(appActions.resetNodeState());
-    dispatch(nodeActions.closeMessagesWebsocket());
+    dispatch(nodeActions.resetState());abortAllPending
     try {
       console.log('Node Admin login from modal');
       const loginInfo = await dispatch(
@@ -489,7 +489,7 @@ function ConnectNodeModal({ open = false, handleClose }: ConnectNodeModalProps) 
               color="primary"
               aria-label="close modal"
               onClick={() => {
-                dispatch(authActions.resetState());
+                dispatch(authActions.removeFailedLogin());
               }}
             >
               <CloseIcon />

--- a/src/store/abortRegistry.ts
+++ b/src/store/abortRegistry.ts
@@ -1,0 +1,20 @@
+type Abortable = { abort: () => void };
+
+const pending = new Set<Abortable>();
+
+export const trackAbortable = (p: Abortable & PromiseLike<unknown>): void => {
+  pending.add(p);
+  const cleanup = () => pending.delete(p);
+  p.then(cleanup, cleanup);
+};
+
+export const abortAllPending = (): void => {
+  pending.forEach((p) => {
+    try {
+      p.abort();
+    } catch {
+      // ignore
+    }
+  });
+  pending.clear();
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,10 +1,24 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, Middleware } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 
 import authSlice from './slices/auth';
 import nodeSlice from './slices/node';
 import appSlice from './slices/app';
+import { trackAbortable } from './abortRegistry';
 //import { websocketMiddleware } from './slices/node/websocketMiddleware';
+
+const abortTrackingMiddleware: Middleware = () => (next) => (action) => {
+  const result = next(action);
+  if (
+    result &&
+    typeof result === 'object' &&
+    typeof (result as { abort?: unknown }).abort === 'function' &&
+    typeof (result as { then?: unknown }).then === 'function'
+  ) {
+    trackAbortable(result as { abort: () => void } & PromiseLike<unknown>);
+  }
+  return result;
+};
 
 const store = configureStore({
   reducer: {
@@ -12,7 +26,7 @@ const store = configureStore({
     node: nodeSlice,
     app: appSlice,
   },
-  //  middleware: (getDefaultMiddleware) => getDefaultMiddleware().prepend(websocketMiddleware),
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().prepend(abortTrackingMiddleware),
   devTools: import.meta.env.PROD ? false : { maxAge: 5000 },
 });
 

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -15,6 +15,13 @@ const authSlice = createSlice({
       if (ADMIN_UI_NODE_LIST) state.nodes = ADMIN_UI_NODE_LIST;
       return state;
     },
+    removeFailedLogin: (state) => {
+      state.status = {
+        connecting: false,
+        connected: false,
+        error: null,
+      };
+    },
     useNodeData(
       state,
       action: PayloadAction<{

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -15,13 +15,6 @@ const authSlice = createSlice({
       if (ADMIN_UI_NODE_LIST) state.nodes = ADMIN_UI_NODE_LIST;
       return state;
     },
-    removeFailedLogin: (state) => {
-      state.status = {
-        connecting: false,
-        connected: false,
-        error: null,
-      };
-    },
     useNodeData(
       state,
       action: PayloadAction<{


### PR DESCRIPTION
Changelog:
- Fixes the URL-based auto-login so it only runs once on initial page load instead of re-triggering on auth state changes.
- Cancels all in-flight API requests when reconnecting to a node, preventing stale responses from leaking into the new session's state after re-login to a different node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of pending operations during logout and connection failures for more reliable state resets.
  * Error overlay close now clears failed-login state so users can retry without a full reset.

* **Performance**
  * Auto-login now runs only once on initial app load to avoid repeated attempts.

* **New Features**
  * Global tracking and bulk-abort of in-progress network operations to prevent stale requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoprnet/node-admin-ui/pull/726)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->